### PR TITLE
clean up integration tests a bit

### DIFF
--- a/cfroutesync/integration/fixtures/invalid-virtual-service.yaml
+++ b/cfroutesync/integration/fixtures/invalid-virtual-service.yaml
@@ -4,7 +4,7 @@ apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
   name: some-name
-  namespace: cf-workloads
+  namespace: default
 spec:
   hosts: [ does-not-matter ]
   http:

--- a/cfroutesync/integration/init_test.go
+++ b/cfroutesync/integration/init_test.go
@@ -1,6 +1,7 @@
 package integration_test
 
 import (
+	"fmt"
 	"math/rand"
 	"testing"
 
@@ -8,8 +9,6 @@ import (
 	ginkgoConfig "github.com/onsi/ginkgo/config"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gexec"
-
-	"k8s.io/client-go/rest"
 )
 
 func TestIntegration(t *testing.T) {
@@ -17,23 +16,20 @@ func TestIntegration(t *testing.T) {
 	RunSpecs(t, "Integration Suite")
 }
 
-var (
-	binaryPathCFRouteSync string
-
-	testEnvConfig *rest.Config
-)
+var binaryPathCFRouteSync string
 
 var _ = SynchronizedBeforeSuite(func() []byte {
+	fmt.Fprintf(GinkgoWriter, "building binary to test...")
 	binaryPathCFRouteSync, err := gexec.Build(
 		"code.cloudfoundry.org/cf-k8s-networking/cfroutesync",
 		"-race",
 	)
 	Expect(err).NotTo(HaveOccurred())
+	fmt.Fprintf(GinkgoWriter, "done")
 	return []byte(binaryPathCFRouteSync)
 }, func(data []byte) {
 	binaryPathCFRouteSync = string(data)
 	rand.Seed(ginkgoConfig.GinkgoConfig.RandomSeed + int64(GinkgoParallelNode()))
-
 })
 
 var _ = SynchronizedAfterSuite(func() {}, func() {

--- a/cfroutesync/webhook/handler.go
+++ b/cfroutesync/webhook/handler.go
@@ -36,7 +36,7 @@ func (r *SyncHandler) ServeHTTP(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	log.WithFields(log.Fields{"request": syncRequest}).Info("metacontroller request received")
+	log.WithFields(log.Fields{"request": syncRequest}).Info("metacontroller webhook request received")
 
 	response, err := r.Syncer.Sync(*syncRequest)
 	if err != nil {


### PR DESCRIPTION
trying to simplify the spec itself, so that it is easier to read.

pulled out a few more helper methods, and moved more of the test setup into `NewTestEnv`

At this point, anything about setting up the dependencies should live there.  Only bits directly related to `cfroutesync` setup will go in the `BeforeEach`

