### PR TITLE
specify full image repo address in cfroutesync Helm templates

### DIFF
--- a/ci/cf-k8s-pipeline.yml
+++ b/ci/cf-k8s-pipeline.yml
@@ -91,6 +91,18 @@ resources:
   source:
     repository: cloudfoundry-incubator/bits-service-release
 
+- name: cfroutesync-image-master
+  type: registry-image
+  source:
+    repository: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync
+    tag: master
+
+- name: cfroutesync-image-latest
+  type: registry-image
+  source:
+    repository: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync
+    tag: latest
+
 groups:
   - name: good-acceptance
     jobs:
@@ -233,6 +245,7 @@ jobs:
   serial_groups: [eirini-dev-1]
   plan:
     - in_parallel:
+        - get: cfroutesync-image-latest
         - get: cf-k8s-networking
         - get: networking-oss-deployments
           passed: [eirini-dev-1-bbl-up]
@@ -246,6 +259,7 @@ jobs:
       file: cf-k8s-networking/ci/tasks/k8s/install-cf-networking.yml
       input_mapping:
         bbl-state: networking-oss-deployments
+        cfroutesync-image: cfroutesync-image-latest
       params:
         KUBECONFIG_CONTEXT: "bosh-eirini-dev-1-cluster"
         BBL_STATE_DIR: "environments/eirini-dev-1"
@@ -474,8 +488,9 @@ jobs:
   serial_groups: [good-acceptance]
   plan:
     - in_parallel:
-        - get: cf-k8s-networking
+        - get: cfroutesync-image-master
           trigger: true
+        - get: cf-k8s-networking
         - get: networking-oss-deployments
           passed: [good-acceptance-deploy-cf, good-acceptance-install-metacontroller, good-acceptance-deploy-istio]
           trigger: true
@@ -489,6 +504,7 @@ jobs:
       file: cf-k8s-networking/ci/tasks/k8s/install-cf-networking.yml
       input_mapping:
         bbl-state: networking-oss-deployments
+        cfroutesync-image: cfroutesync-image-master
       params:
         KUBECONFIG_CONTEXT: "bosh-good-acceptance-cluster"
         BBL_STATE_DIR: "environments/good-acceptance"

--- a/ci/tasks/k8s/install-cf-networking.sh
+++ b/ci/tasks/k8s/install-cf-networking.sh
@@ -25,7 +25,9 @@ function install() {
   kubectl apply -f "cf-k8s-networking/cfroutesync/crds/routebulksync.yaml"
 
   echo 'Deploying to Kubernetes...'
-  helm template cf-k8s-networking/install/helm/networking/ --values $secrets_yaml | kubectl apply -f-
+  image_digest="$(cat cfroutesync-image/digest)"
+  image_repo="gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@${image_digest}"
+  helm template cf-k8s-networking/install/helm/networking/ --values $secrets_yaml --set cfroutesync.image=${image_repo} | kubectl apply -f-
 }
 
 function main() {

--- a/ci/tasks/k8s/install-cf-networking.yml
+++ b/ci/tasks/k8s/install-cf-networking.yml
@@ -9,6 +9,7 @@ inputs:
   - name: cf-k8s-networking
   - name: bbl-state
   - name: kubeconfig
+  - name: cfroutesync-image
 
 run:
   path: cf-k8s-networking/ci/tasks/k8s/install-cf-networking.sh

--- a/install/helm/networking/templates/cfroutesync.yaml
+++ b/install/helm/networking/templates/cfroutesync.yaml
@@ -38,7 +38,7 @@ spec:
     spec:
       containers:
         - name: cfroutesync
-          image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:{{ .Values.cfroutesync.version }}
+          image: {{ .Values.cfroutesync.image }}
           args: [ "-c", "/etc/cfroutesync-config"]
           volumeMounts:
             - name: cfroutesync-config

--- a/install/helm/networking/values.yaml
+++ b/install/helm/networking/values.yaml
@@ -5,7 +5,8 @@ systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
 cfroutesync:
-  version: latest
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
+
   # The values below are placeholders for configuring templates/cfroutesync-secret.yaml
   ccCA: 'path_to_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'


### PR DESCRIPTION
I wanted to update CI to deploy specific image digests to
ensure we're deploying and testing consistent code artifacts. Unfortunately the syntax for specifying an image by digest is a little different than it is for specifying an image by tag.

`image:some-tag` vs `image@sha256:42a0cbc91cb373b1b4c929525df1ac72a5086606a7d1bdb4a8ffb3d4271ac094`

This meant that using `version` to mean "image tag" in our Helm templates wasn't going to work. We can either replace `version` with explicit `tag` and `digest` values (with `digest` taking precedence) and do some conditional templating like:

```
{{ if .Values.cfroutesync.digest }}
image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync@{{ .Values.cfroutesync.digest }}
{{ else }}
image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:{{ .Values.cfroutesync.tag }}
{{ end }}
```

Or we could just have a single `image` property that takes the full repository + tag/digest string. I went with the second option because it felt simplest and would allow for consumers to easily use other registries. There are other options, though, so happy to change.

I found this discussion on this tag vs digest problem interesting: https://github.com/helm/charts/issues/13449

Story: [#168850471](https://www.pivotaltracker.com/story/show/168850471)