### PR TITLE
refactor: extract secrets from Secret to ConfigMap

### DIFF
--- a/cfroutesync/main.go
+++ b/cfroutesync/main.go
@@ -31,9 +31,12 @@ func mainWithError() error {
 	log.SetFormatter(&log.JSONFormatter{})
 	log.SetOutput(os.Stdout)
 
-	var configDir string
-	var listenAddr string
-	var verbosity int
+	var (
+		configDir  string
+		listenAddr string
+		verbosity  int
+	)
+
 	flag.StringVar(&configDir, "c", "", "config directory")
 	flag.StringVar(&listenAddr, "l", ":8080", "listen address for serving webhook to metacontroller")
 	flag.IntVar(&verbosity, "v", 4, "log verbosity")
@@ -44,7 +47,7 @@ func mainWithError() error {
 		return fmt.Errorf("missing required flag for config dir")
 	}
 
-	config, err := cfg.FromDir(configDir)
+	config, err := cfg.Load(configDir)
 	if err != nil {
 		return fmt.Errorf("loading config: %w", err)
 	}

--- a/install/helm/networking/templates/cfroutesync-configmap.yaml
+++ b/install/helm/networking/templates/cfroutesync-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cfroutesync
+  namespace: {{ .Values.systemNamespace }}
+data:
+  ccBaseURL: {{.Values.cfroutesync.ccBaseURL}}
+  uaaBaseURL: {{.Values.cfroutesync.uaaBaseURL}}
+  ccCA: |
+{{.Values.cfroutesync.ccCA | indent 4 }}
+  uaaCA: |
+{{.Values.cfroutesync.uaaCA | indent 4 }}
+  clientName: {{.Values.cfroutesync.clientName}}
+  {{/* quotes are required to support empty values */}}
+  eiriniPodLabelPrefix: "{{.Values.cfroutesync.eiriniPodLabelPrefix}}"

--- a/install/helm/networking/templates/cfroutesync-secret.yaml
+++ b/install/helm/networking/templates/cfroutesync-secret.yaml
@@ -1,15 +1,8 @@
 apiVersion: v1
-data:
-  ccCA: {{.Values.cfroutesync.ccCA}}
-  ccBaseURL: {{.Values.cfroutesync.ccBaseURL}}
-  uaaCA: {{.Values.cfroutesync.uaaCA}}
-  uaaBaseURL: {{.Values.cfroutesync.uaaBaseURL}}
-  clientName: {{.Values.cfroutesync.clientName}}
-  clientSecret: {{.Values.cfroutesync.clientSecret}}
-  {{/* quotes are required to support empty values */}}
-  eiriniPodLabelPrefix: "{{.Values.cfroutesync.eiriniPodLabelPrefix}}"
 kind: Secret
 metadata:
   name: cfroutesync
   namespace: {{ .Values.systemNamespace }}
 type: Opaque
+data:
+  clientSecret: {{.Values.cfroutesync.clientSecret}}

--- a/install/helm/networking/templates/cfroutesync.yaml
+++ b/install/helm/networking/templates/cfroutesync.yaml
@@ -40,12 +40,15 @@ spec:
         - name: cfroutesync
           image: {{ .Values.cfroutesync.image }}
           args: [ "-c", "/etc/cfroutesync-config"]
+          envFrom:
+            - configMapRef:
+                name: cfroutesync
           volumeMounts:
-            - name: cfroutesync-config
+            - name: cfroutesync-credentials
               mountPath: /etc/cfroutesync-config
               readOnly: true
       volumes:
-        - name: cfroutesync-config
+        - name: cfroutesync-credentials
           secret:
             secretName: cfroutesync
 ---

--- a/install/helm/networking/values.yaml
+++ b/install/helm/networking/values.yaml
@@ -7,12 +7,10 @@ workloadsNamespace: cf-workloads
 cfroutesync:
   image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
 
-  # The values below are placeholders for configuring templates/cfroutesync-secret.yaml
-  # real values should be base64 encoded
-  ccCA: 'cloud_controller_ca'
+  ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'
-  uaaCA: 'uaa_ca'
+  uaaCA: 'base64_encoded_uaa_ca'
   uaaBaseURL: 'https://uaa.example.com'
   clientName: 'uaaClientName'
-  clientSecret: 'uaaClientSecret'
+  clientSecret: 'base64_encoded_uaaClientSecret'
   eiriniPodLabelPrefix: 'eiriniPodLabelPrefix'

--- a/install/scripts/generate_values.rb
+++ b/install/scripts/generate_values.rb
@@ -37,12 +37,12 @@ eirini_pod_label_prefix = "cloudfoundry.org/"
 
 puts YAML.dump({
         'cfroutesync' => {
-          'ccCA' => Base64.strict_encode64(lb_cert_ca),
-          'ccBaseURL' => Base64.strict_encode64(cc_base_url),
-          'uaaCA' => Base64.strict_encode64(lb_cert_ca),
-          'uaaBaseURL' => Base64.strict_encode64(uaa_base_url),
-          'clientName' => Base64.strict_encode64(client_name),
+          'ccCA' => lb_cert_ca,
+          'ccBaseURL' => cc_base_url,
+          'uaaCA' => lb_cert_ca,
+          'uaaBaseURL' => uaa_base_url,
+          'clientName' => client_name,
           'clientSecret' => Base64.strict_encode64(client_secret),
-          'eiriniPodLabelPrefix' => Base64.strict_encode64(eirini_pod_label_prefix),
+          'eiriniPodLabelPrefix' => eirini_pod_label_prefix,
         }
   })


### PR DESCRIPTION
- we had some configurations which didn't require keeping them hashed
- having those configuration in plain text make them easier to change,
e.g. via `kubectl edit`
- easier to provide values for those configruration via Helm (no need to
encrypt to base64)