### PR TITLE
feat: use stringData in cfroutesync-secret

### DIFF
--- a/install/scripts/generate_values.rb
+++ b/install/scripts/generate_values.rb
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require 'json'
-require 'base64'
 require 'yaml'
 
 puts "#! Generating values to use with YTT/helm template"
@@ -43,7 +42,7 @@ puts YAML.dump({
           'uaaCA' => lb_cert_ca,
           'uaaBaseURL' => uaa_base_url,
           'clientName' => client_name,
-          'clientSecret' => Base64.strict_encode64(client_secret),
+          'clientSecret' => client_secret,
           'eiriniPodLabelPrefix' => eirini_pod_label_prefix,
         }
   })

--- a/install/ytt/networking/templates/cfroutesync-secret.yaml
+++ b/install/ytt/networking/templates/cfroutesync-secret.yaml
@@ -6,5 +6,5 @@ metadata:
   name: cfroutesync
   namespace: #@ data.values.systemNamespace
 type: Opaque
-data:
+stringData:
   clientSecret: #@ data.values.cfroutesync.clientSecret


### PR DESCRIPTION
> The stringData field is provided for convenience, and allows you to provide secret data as unencoded strings.
https://kubernetes.io/docs/concepts/configuration/secret/

This slightly improves the installation UX so that operators
do not need to base64 encode cfroutesync's uaaClientSecret

Obviates the need for https://github.com/cloudfoundry/cf-k8s-networking/pull/9