### PR TITLE
feat: hardcode the pod prefix label

### DIFF
--- a/cfroutesync/cfg/cfg.go
+++ b/cfroutesync/cfg/cfg.go
@@ -36,21 +36,15 @@ type Config struct {
 		// List of Istio Gateway names to use for workload ingress
 		Gateways []string
 	}
-
-	Experimental struct {
-		// Controls compatibility with Eirini pre-1.0 vs post-1.0
-		EiriniPodLabelPrefix string
-	}
 }
 
 const (
-	FileUAABaseURL           = "uaaBaseURL"
-	FileUAAClientName        = "clientName"
-	FileUAAClientSecret      = "clientSecret"
-	FileUAACA                = "uaaCA"
-	FileCCBaseURL            = "ccBaseURL"
-	FileCCCA                 = "ccCA"
-	FileEiriniPodLabelPrefix = "eiriniPodLabelPrefix"
+	FileUAABaseURL      = "uaaBaseURL"
+	FileUAAClientName   = "clientName"
+	FileUAAClientSecret = "clientSecret"
+	FileUAACA           = "uaaCA"
+	FileCCBaseURL       = "ccBaseURL"
+	FileCCCA            = "ccCA"
 )
 
 // Load loads a Config from environment variables or files within a directory on disk
@@ -72,7 +66,6 @@ func Load(configDir string) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	podLabelPrefix, err := loadValue(configDir, FileEiriniPodLabelPrefix)
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +88,6 @@ func Load(configDir string) (*Config, error) {
 	c.CC.BaseURL = ccBaseUrl
 	c.CC.CA = ccCA
 	c.Istio.Gateways = []string{"istio-ingress"}
-	c.Experimental.EiriniPodLabelPrefix = podLabelPrefix
 	return c, nil
 }
 

--- a/cfroutesync/integration/testenv_test.go
+++ b/cfroutesync/integration/testenv_test.go
@@ -163,13 +163,12 @@ func (te *TestEnv) setupConfigDirForCfroutesync() error {
 	}
 
 	for filename, contents := range map[string]string{
-		cfg.FileUAABaseURL:           te.FakeUAA.Server.URL,
-		cfg.FileUAAClientName:        "fake-uaa-client-name",
-		cfg.FileUAAClientSecret:      "fake-uaa-client-secret",
-		cfg.FileUAACA:                string(fakeUAACertBytes),
-		cfg.FileCCBaseURL:            te.FakeCC.Server.URL,
-		cfg.FileCCCA:                 string(fakeCCCertBytes),
-		cfg.FileEiriniPodLabelPrefix: "",
+		cfg.FileUAABaseURL:      te.FakeUAA.Server.URL,
+		cfg.FileUAAClientName:   "fake-uaa-client-name",
+		cfg.FileUAAClientSecret: "fake-uaa-client-secret",
+		cfg.FileUAACA:           string(fakeUAACertBytes),
+		cfg.FileCCBaseURL:       te.FakeCC.Server.URL,
+		cfg.FileCCCA:            string(fakeCCCertBytes),
 	} {
 		if err := ioutil.WriteFile(filepath.Join(te.CfRouteSyncConfigDir, filename), []byte(contents), 0644); err != nil {
 			return err

--- a/cfroutesync/main.go
+++ b/cfroutesync/main.go
@@ -104,9 +104,7 @@ func mainWithError() error {
 		Syncer: &webhook.Lineage{
 			RouteSnapshotRepo: snapshotRepo,
 			K8sResourceBuilders: []webhook.K8sResourceBuilder{
-				&webhook.ServiceBuilder{
-					PodLabelPrefix: config.Experimental.EiriniPodLabelPrefix,
-				},
+				&webhook.ServiceBuilder{},
 				&webhook.VirtualServiceBuilder{IstioGateways: config.Istio.Gateways},
 			},
 		},

--- a/cfroutesync/webhook/service_builder.go
+++ b/cfroutesync/webhook/service_builder.go
@@ -8,21 +8,19 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-type ServiceBuilder struct {
-	PodLabelPrefix string
-}
+type ServiceBuilder struct{}
 
 func (b *ServiceBuilder) Build(routes []models.Route, template Template) []K8sResource {
 	resources := []K8sResource{}
 	for _, route := range routes {
-		for _, s := range b.routeToServices(route, template) {
+		for _, s := range routeToServices(route, template) {
 			resources = append(resources, s)
 		}
 	}
 	return resources
 }
 
-func (b *ServiceBuilder) routeToServices(route models.Route, template Template) []Service {
+func routeToServices(route models.Route, template Template) []Service {
 	const httpPortName = "http"
 	services := []Service{}
 	for _, dest := range route.Destinations {
@@ -36,8 +34,8 @@ func (b *ServiceBuilder) routeToServices(route models.Route, template Template) 
 			},
 			Spec: ServiceSpec{
 				Selector: map[string]string{
-					b.PodLabelPrefix + "app_guid":     dest.App.Guid,
-					b.PodLabelPrefix + "process_type": dest.App.Process.Type,
+					"cloudfoundry.org/app_guid":     dest.App.Guid,
+					"cloudfoundry.org/process_type": dest.App.Process.Type,
 				},
 				Ports: []ServicePort{
 					{

--- a/cfroutesync/webhook/service_builder.go
+++ b/cfroutesync/webhook/service_builder.go
@@ -22,6 +22,7 @@ func (b *ServiceBuilder) Build(routes []models.Route, template Template) []K8sRe
 
 func routeToServices(route models.Route, template Template) []Service {
 	const httpPortName = "http"
+	const podLabelPrefix = "cloudfoundry.org/"
 	services := []Service{}
 	for _, dest := range route.Destinations {
 		service := Service{
@@ -34,8 +35,8 @@ func routeToServices(route models.Route, template Template) []Service {
 			},
 			Spec: ServiceSpec{
 				Selector: map[string]string{
-					"cloudfoundry.org/app_guid":     dest.App.Guid,
-					"cloudfoundry.org/process_type": dest.App.Process.Type,
+					podLabelPrefix + "app_guid":     dest.App.Guid,
+					podLabelPrefix + "process_type": dest.App.Process.Type,
 				},
 				Ports: []ServicePort{
 					{

--- a/cfroutesync/webhook/service_builder_test.go
+++ b/cfroutesync/webhook/service_builder_test.go
@@ -123,8 +123,8 @@ var _ = Describe("ServiceBuilder", func() {
 				},
 				Spec: webhook.ServiceSpec{
 					Selector: map[string]string{
-						"custom-pod-label-prefix/app_guid":     "app-guid-0",
-						"custom-pod-label-prefix/process_type": "process-type-1",
+						"cloudfoundry.org/app_guid":     "app-guid-0",
+						"cloudfoundry.org/process_type": "process-type-1",
 					},
 
 					Ports: []webhook.ServicePort{
@@ -153,8 +153,8 @@ var _ = Describe("ServiceBuilder", func() {
 				},
 				Spec: webhook.ServiceSpec{
 					Selector: map[string]string{
-						"custom-pod-label-prefix/app_guid":     "app-guid-1",
-						"custom-pod-label-prefix/process_type": "process-type-1",
+						"cloudfoundry.org/app_guid":     "app-guid-1",
+						"cloudfoundry.org/process_type": "process-type-1",
 					},
 
 					Ports: []webhook.ServicePort{
@@ -183,8 +183,8 @@ var _ = Describe("ServiceBuilder", func() {
 				},
 				Spec: webhook.ServiceSpec{
 					Selector: map[string]string{
-						"custom-pod-label-prefix/app_guid":     "app-guid-2",
-						"custom-pod-label-prefix/process_type": "process-type-2",
+						"cloudfoundry.org/app_guid":     "app-guid-2",
+						"cloudfoundry.org/process_type": "process-type-2",
 					},
 
 					Ports: []webhook.ServicePort{
@@ -213,8 +213,8 @@ var _ = Describe("ServiceBuilder", func() {
 				},
 				Spec: webhook.ServiceSpec{
 					Selector: map[string]string{
-						"custom-pod-label-prefix/app_guid":     "app-guid-1",
-						"custom-pod-label-prefix/process_type": "process-type-1",
+						"cloudfoundry.org/app_guid":     "app-guid-1",
+						"cloudfoundry.org/process_type": "process-type-1",
 					},
 
 					Ports: []webhook.ServicePort{
@@ -227,9 +227,8 @@ var _ = Describe("ServiceBuilder", func() {
 			},
 		}
 
-		builder := webhook.ServiceBuilder{
-			PodLabelPrefix: "custom-pod-label-prefix/",
-		}
+		builder := webhook.ServiceBuilder{}
+
 		Expect(builder.Build(routes, template)).To(Equal(expectedServices))
 	})
 

--- a/config/cfroutesync/cfroutesync-configmap.yaml
+++ b/config/cfroutesync/cfroutesync-configmap.yaml
@@ -14,4 +14,3 @@ data:
   ccCA: #@ data.values.cfroutesync.ccCA
   uaaCA: #@ data.values.cfroutesync.uaaCA
   clientName: #@ data.values.cfroutesync.clientName
-  eiriniPodLabelPrefix: #@ data.values.cfroutesync.eiriniPodLabelPrefix

--- a/config/cfroutesync/values.yaml
+++ b/config/cfroutesync/values.yaml
@@ -16,7 +16,6 @@ cfroutesync:
   uaaBaseURL: 'https://uaa.example.com'
   clientName: 'uaaClientName'
   clientSecret: 'base64_encoded_uaaClientSecret'
-  eiriniPodLabelPrefix: 'eiriniPodLabelPrefix'
 
 service:
   externalPort: 80

--- a/config/scripts/generate_values.rb
+++ b/config/scripts/generate_values.rb
@@ -43,6 +43,5 @@ puts YAML.dump({
           'uaaBaseURL' => uaa_base_url,
           'clientName' => client_name,
           'clientSecret' => client_secret,
-          'eiriniPodLabelPrefix' => eirini_pod_label_prefix,
         }
   })


### PR DESCRIPTION
- We deleted the flag that makes the prefix label customizable and hardcode
the value "cloudfoundry.org/"

[#169873095](https://www.pivotaltracker.com/story/show/169873095)

Co-authored-by: Rodolfo Sanchez <rsanchez@pivotal.io>


following the PR https://github.com/cloudfoundry/cf-k8s-networking/pull/17/files