### PR TITLE
feat: extract tag from cfroutesync Pod image url

### DIFF
--- a/config/cfroutesync/cfroutesync.yaml
+++ b/config/cfroutesync/cfroutesync.yaml
@@ -45,7 +45,7 @@ spec:
     spec:
       containers:
         - name: cfroutesync
-          image: #@ data.values.cfroutesync.image
+          image: #@ "{}:{}".format(data.values.cfroutesync.image, data.values.cfroutesync.tag)
           args: [ "-c", "/etc/cfroutesync-config"]
           imagePullPolicy: Always
           envFrom:

--- a/config/cfroutesync/values.yaml
+++ b/config/cfroutesync/values.yaml
@@ -8,7 +8,8 @@ workloadsNamespace: cf-workloads
 istioNamespace: istio-system
 
 cfroutesync:
-  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
+  image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync
+  tag: latest
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'


### PR DESCRIPTION
Looked how Istio did it [here](https://github.com/istio/istio/blob/ab5aae298b122a038e9b716934d1be57b374623f/install/kubernetes/helm/istio/charts/galley/templates/deployment.yaml#L44)