### PR TITLE
WIP: config: add recommended labels to cfroutesync objects

### DIFF
--- a/config/cfroutesync/cfroutesync-configmap.yaml
+++ b/config/cfroutesync/cfroutesync-configmap.yaml
@@ -1,3 +1,4 @@
+#@ load("commons.lib.yaml", "labels")
 #@ load("@ytt:data", "data")
 ---
 apiVersion: v1
@@ -8,6 +9,7 @@ metadata:
   annotations:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/num-versions: "2"
+  labels: #@ labels()
 data:
   ccBaseURL: #@ data.values.cfroutesync.ccBaseURL
   uaaBaseURL: #@ data.values.cfroutesync.uaaBaseURL

--- a/config/cfroutesync/cfroutesync-secret.yaml
+++ b/config/cfroutesync/cfroutesync-secret.yaml
@@ -1,10 +1,13 @@
 #@ load("@ytt:data", "data")
+#@ load("commons.lib.yaml", "labels")
+
 ---
 apiVersion: v1
 kind: Secret
 metadata:
   name: cfroutesync
   namespace: #@ data.values.systemNamespace
+  labels: #@ labels()
 type: Opaque
 stringData:
   clientSecret: #@ data.values.cfroutesync.clientSecret

--- a/config/cfroutesync/cfroutesync.yaml
+++ b/config/cfroutesync/cfroutesync.yaml
@@ -1,14 +1,12 @@
 #@ load("@ytt:data", "data")
-
-#@ def labels():
-app: cfroutesync
-#@ end
+#@ load("commons.lib.yaml", "labels")
 
 ---
 apiVersion: metacontroller.k8s.io/v1alpha1
 kind: CompositeController
 metadata:
   name: cfroutesync
+  labels: #@ labels()
 spec:
   resyncPeriodSeconds: 5
   parentResource:
@@ -35,6 +33,7 @@ metadata:
   namespace: #@ data.values.systemNamespace
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels: #@ labels()
 spec:
   selector:
     matchLabels: #@ labels()
@@ -65,6 +64,7 @@ kind: Service
 metadata:
   name: cfroutesync
   namespace: #@ data.values.systemNamespace
+  labels: #@ labels()
 spec:
   selector: #@ labels()
   ports:
@@ -77,6 +77,7 @@ kind: RouteBulkSync
 metadata:
   name: route-bulk-sync
   namespace: #@ data.values.workloadsNamespace
+  labels: #@ labels()
 spec:
   selector:
     matchLabels:
@@ -91,6 +92,7 @@ kind: AuthorizationPolicy
 metadata:
   name: cfroutesync-auth-metacontroller
   namespace: #@ data.values.systemNamespace
+  labels: #@ labels()
 spec:
   selector:
     matchLabels: #@ labels()
@@ -109,6 +111,7 @@ kind: AuthorizationPolicy
 metadata:
   name: cfroutesync-auth-prometheus
   namespace: #@ data.values.systemNamespace
+  labels: #@ labels()
 spec:
   selector:
     matchLabels: #@ labels()

--- a/config/cfroutesync/commons.lib.yaml
+++ b/config/cfroutesync/commons.lib.yaml
@@ -1,0 +1,10 @@
+#@ load("@ytt:data", "data")
+
+#@ def labels(instance="abcd"):
+app: cfroutesync
+app.kubernetes.io/name: cfroutesync
+app.kubernetes.io/instance: #@ instance
+app.kubernetes.io/version: #@ data.values.cfroutesync.version
+app.kubernetes.io/part-of: cf
+app.kubernetes.io/component: networking
+#@ end

--- a/config/cfroutesync/istio-cfrequestcount.yaml
+++ b/config/cfroutesync/istio-cfrequestcount.yaml
@@ -1,3 +1,5 @@
+#@ load("commons.lib.yaml", "labels")
+
 #! handler, instance, and rule to add custom cfrequestcount metric
 #! this custom metric adds the "source_name" label_name so requests can be
 #! counted by ingressgateway pod
@@ -6,6 +8,7 @@ kind: handler
 metadata:
   name: cf-prometheus
   namespace: istio-system
+  labels: #@ labels()
 spec:
   compiledAdapter: prometheus
   params:

--- a/config/cfroutesync/istio-gateway.yaml
+++ b/config/cfroutesync/istio-gateway.yaml
@@ -1,10 +1,12 @@
 #@ load("@ytt:data", "data")
+#@ load("commons.lib.yaml", "labels")
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
   name: istio-ingress
   namespace: #@ data.values.workloadsNamespace
+  labels: #@ labels()
 spec:
   selector:
     istio: ingressgateway

--- a/config/cfroutesync/values.yaml
+++ b/config/cfroutesync/values.yaml
@@ -9,6 +9,7 @@ istioNamespace: istio-system
 
 cfroutesync:
   image: gcr.io/cf-networking-images/cf-k8s-networking/cfroutesync:latest
+  version: "0.0.1-alpha1"
 
   ccCA: 'base64_encoded_cloud_controller_ca'
   ccBaseURL: 'https://api.example.com'


### PR DESCRIPTION
* following guideline at https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/

I was looking at what other system components, such CAPI and UAA did, and found, that, for example, CAPI sets some of the recommended labels (e.g. `app.kubernetes.io/name`). I was wondering why we don't so I opened this PR.

I think all system components should adopt these labels.
