### PR TITLE
fix: url encode UAA oAuth client credentials

### DIFF
--- a/cfroutesync/uaaclient/client.go
+++ b/cfroutesync/uaaclient/client.go
@@ -3,6 +3,7 @@ package uaaclient
 import (
 	"fmt"
 	"net/http"
+	"net/url"
 	"strings"
 )
 
@@ -20,12 +21,14 @@ type jsonClient interface {
 
 func (c *Client) GetToken() (string, error) {
 	reqURL := fmt.Sprintf("%s/oauth/token", c.BaseURL)
-	bodyString := fmt.Sprintf("client_id=%s&grant_type=client_credentials", c.Name)
+	bodyString := fmt.Sprintf("grant_type=client_credentials")
+
 	request, err := http.NewRequest("POST", reqURL, strings.NewReader(bodyString))
 	if err != nil {
 		return "", err
 	}
-	request.SetBasicAuth(c.Name, c.Secret)
+
+	request.SetBasicAuth(url.QueryEscape(c.Name), url.QueryEscape(c.Secret))
 	request.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 	type getTokenResponse struct {


### PR DESCRIPTION
Although this header was base64 encoded, the oAuth spec requires
that is also be url encoded. This was causing client credentials
that contained special characters (e.g. `+`) to be rejected by UAA:

```json
{"error":"uaa get token: bad response, code 401: {\"error\":\"unauthorized\",\"error_description\":\"Bad credentials\"}","level":"error","msg":"fetching","time":"2020-02-18T23:49:41Z"}
```

> The client identifier is encoded using the
   "application/x-www-form-urlencoded" encoding algorithm per
   Appendix B, and the encoded value is used as the username; the client
   password is encoded using the same algorithm and used as the
   password.

https://tools.ietf.org/html/rfc6749#section-2.3.1

**Related:**
https://github.com/golang/oauth2/issues/320

**Tracker Story:**
[#171268188](https://www.pivotaltracker.com/story/show/171268188)

Thanks to @joshuatcasey for helping me make sense of the oAuth spec!