### PR TITLE
make yaml comment ytt-friendly

### DIFF
--- a/config/no-loadbalancer/node-to-ingressgateway-daemonset.yaml
+++ b/config/no-loadbalancer/node-to-ingressgateway-daemonset.yaml
@@ -1,4 +1,4 @@
-# See README for usage information at doc/no-loadbalancer/README.md
+#! See README for usage information at doc/no-loadbalancer/README.md
 
 ---
 apiVersion: v1


### PR DESCRIPTION
Release Engineering would like to consume this using the k14s kapp/ytt stack.

This notifies ytt that the comment is intended for humans.