### PR TITLE
Allow traffic to istio-sidecar-injector on port 9443.

### DIFF
--- a/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio-generated/xxx-generated-istio.yaml
@@ -9933,15 +9933,8 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          cf-for-k8s.cloudfoundry.org/istio-system-ns: ""
-    ports:
-    - port: 9091
-    - port: 15004
-    - port: 15090
-    - port: 42422
+  - ports:
+    - port: 9443
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/config/istio/overlays/lock-it-down.yaml
+++ b/config/istio/overlays/lock-it-down.yaml
@@ -78,13 +78,8 @@ spec:
   policyTypes:
   - Ingress
   ingress:
-  - from:
-    - #@ istio_ns_selector()
-    ports:
-    - port: #@ data.values.istio_ports.policy_telemetry
-    - port: #@ data.values.istio_ports.policy_telemetry_mtls
-    - port: #@ data.values.istio_ports.proxy
-    - port: #@ data.values.istio_ports.telemetry_prometheus
+  - ports:
+    - port: #@ data.values.istio_ports.sidecar_injector
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy

--- a/config/istio/ytt-data-values.yaml
+++ b/config/istio/ytt-data-values.yaml
@@ -13,3 +13,4 @@ istio_ports:
   sds_service_monitoring: 8080 #! used by Citadel agent
   sni_monitoring: 15443 #! used by Ingress and Egress Gateways.
   telemetry_prometheus: 42422 #! used by Mixer
+  sidecar_injector: 9443 #! used by the K8s API server


### PR DESCRIPTION
# Problem
NetworkPolicy blocks traffic from API server to `istio-sidecar-injector`.

# Solution
- Allow everyone to access `istio-sidecar-injector` on its https port.
- Remove other ports from NetworkPolicy.
- Remove NamespaceSelector since API server has no namespace.

Fixes https://github.com/cloudfoundry/cf-for-k8s/issues/69