### PR TITLE
Added Control Plane monitoring port to pilot network policy

### DIFF
--- a/config/istio/overlays/lock-it-down.yaml
+++ b/config/istio/overlays/lock-it-down.yaml
@@ -22,6 +22,7 @@ spec:
     - port: #@ data.values.istio_ports.policy_telemetry_mtls
     - port: #@ data.values.istio_ports.pilot_service_discovery
     - port: #@ data.values.istio_ports.pilot_service_proxy_discovery_mtls
+    - port: #@ data.values.istio_ports.control_plane_monitoring
 
 ---
 apiVersion: networking.k8s.io/v1


### PR DESCRIPTION
Control Plane monitoring port is not added for pilot network policy, because of which unable to fetch pilot metrics. This PR adds the port to allow ingress traffic