### PR TITLE
Update istio build script to use kbld to pin the istio images to digests

### DIFF
--- a/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio-generated/xxx-generated-istio.yaml
@@ -1,10 +1,11 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-istio-system
 rules:
 - apiGroups:
   - config.istio.io
@@ -42,10 +43,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-reader-istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -4697,26 +4698,26 @@ spec:
     served: true
     storage: true
 ---
-kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: adapters.config.istio.io
   labels:
     app: mixer
-    package: adapter
-    istio: mixer-adapter
     chart: istio
     heritage: Tiller
+    istio: mixer-adapter
+    package: adapter
     release: istio
+  name: adapters.config.istio.io
 spec:
   group: config.istio.io
   names:
+    categories:
+    - istio-io
+    - policy-istio-io
     kind: adapter
     plural: adapters
     singular: adapter
-    categories:
-    - istio-io
-    - policy-istio-io
   scope: Namespaced
   subresources:
     status: {}
@@ -4725,26 +4726,26 @@ spec:
     served: true
     storage: true
 ---
-kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: instances.config.istio.io
   labels:
     app: mixer
-    package: instance
-    istio: mixer-instance
     chart: istio
     heritage: Tiller
+    istio: mixer-instance
+    package: instance
     release: istio
+  name: instances.config.istio.io
 spec:
   group: config.istio.io
   names:
+    categories:
+    - istio-io
+    - policy-istio-io
     kind: instance
     plural: instances
     singular: instance
-    categories:
-    - istio-io
-    - policy-istio-io
   scope: Namespaced
   subresources:
     status: {}
@@ -4753,26 +4754,26 @@ spec:
     served: true
     storage: true
 ---
-kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: templates.config.istio.io
   labels:
     app: mixer
-    package: template
-    istio: mixer-template
     chart: istio
     heritage: Tiller
+    istio: mixer-template
+    package: template
     release: istio
+  name: templates.config.istio.io
 spec:
   group: config.istio.io
   names:
+    categories:
+    - istio-io
+    - policy-istio-io
     kind: template
     plural: templates
     singular: template
-    categories:
-    - istio-io
-    - policy-istio-io
   scope: Namespaced
   subresources:
     status: {}
@@ -4781,26 +4782,26 @@ spec:
     served: true
     storage: true
 ---
-kind: CustomResourceDefinition
 apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
 metadata:
-  name: handlers.config.istio.io
   labels:
     app: mixer
-    package: handler
-    istio: mixer-handler
     chart: istio
     heritage: Tiller
+    istio: mixer-handler
+    package: handler
     release: istio
+  name: handlers.config.istio.io
 spec:
   group: config.istio.io
   names:
-    kind: handler
-    plural: handlers
-    singular: handler
     categories:
     - istio-io
     - policy-istio-io
+    kind: handler
+    plural: handlers
+    singular: handler
   scope: Namespaced
   subresources:
     status: {}
@@ -5065,27 +5066,27 @@ spec:
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: istio-system
   labels:
-    istio-operator-managed: Reconcile
     istio-injection: disabled
+    istio-operator-managed: Reconcile
+  name: istio-system
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-reader-service-account
-  namespace: istio-system
   labels:
     app: istio-reader
     release: istio
+  name: istio-reader-service-account
+  namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-citadel-istio-system
   labels:
     app: citadel
     release: istio
+  name: istio-citadel-istio-system
 rules:
 - apiGroups:
   - ""
@@ -5126,9 +5127,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-citadel-istio-system
   labels:
     release: istio
+  name: istio-citadel-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5141,6 +5142,13 @@ subjects:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/citadel:1.4.5
+        URL: index.docker.io/istio/citadel@sha256:420a331a528886aca47bed5b8c549c78d594e52d771f876f3137d3557207712f
   labels:
     app: security
     istio: citadel
@@ -5209,7 +5217,7 @@ spec:
         env:
         - name: CITADEL_ENABLE_NAMESPACES_BY_DEFAULT
           value: "true"
-        image: docker.io/istio/citadel:1.4.5
+        image: index.docker.io/istio/citadel@sha256:420a331a528886aca47bed5b8c549c78d594e52d771f876f3137d3557207712f
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -5226,14 +5234,14 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-citadel
-  namespace: istio-system
+  annotations:
+    kapp.k14s.io/update-strategy: fallback-on-replace
   labels:
     app: security
     istio: citadel
     release: istio
-  annotations:
-    kapp.k14s.io/update-strategy: fallback-on-replace
+  name: istio-citadel
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -5244,18 +5252,18 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-citadel
-  namespace: istio-system
   labels:
     app: security
     istio: citadel
     release: istio
+  name: istio-citadel
+  namespace: istio-system
 spec:
   ports:
   - name: grpc-citadel
     port: 8060
-    targetPort: 8060
     protocol: TCP
+    targetPort: 8060
   - name: http-monitoring
     port: 15014
   selector:
@@ -5264,18 +5272,18 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-citadel-service-account
-  namespace: istio-system
   labels:
     app: security
     release: istio
+  name: istio-citadel-service-account
+  namespace: istio-system
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-galley-istio-system
   labels:
     release: istio
+  name: istio-galley-istio-system
 rules:
 - apiGroups:
   - authentication.istio.io
@@ -5308,10 +5316,10 @@ rules:
 - apiGroups:
   - extensions
   - apps
-  resources:
-  - deployments
   resourceNames:
   - istio-galley
+  resources:
+  - deployments
   verbs:
   - get
 - apiGroups:
@@ -5360,9 +5368,9 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-galley-admin-role-binding-istio-system
   labels:
     release: istio
+  name: istio-galley-admin-role-binding-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -5373,14 +5381,6 @@ subjects:
   namespace: istio-system
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: galley-envoy-config
-  labels:
-    app: galley
-    istio: galley
-    release: istio
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -5460,24 +5460,26 @@ data:
                 trusted_ca:
                   filename: /etc/certs/root-cert.pem
             require_client_certificate: true
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-mesh-galley
-  namespace: istio-system
   labels:
+    app: galley
+    istio: galley
     release: istio
+  name: galley-envoy-config
+  namespace: istio-system
+---
+apiVersion: v1
 data:
   mesh: '{}'
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio-galley-configuration
-  namespace: istio-system
   labels:
     release: istio
+  name: istio-mesh-galley
+  namespace: istio-system
+---
+apiVersion: v1
 data:
   validatingwebhookconfiguration.yaml: |-
     apiVersion: admissionregistration.k8s.io/v1beta1
@@ -5604,10 +5606,28 @@ data:
             - zipkins
         failurePolicy: Fail
         sideEffects: None
+kind: ConfigMap
+metadata:
+  labels:
+    release: istio
+  name: istio-galley-configuration
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/galley:1.4.5
+        URL: index.docker.io/istio/galley@sha256:26e744bdfd3db289d4cfc9be63e38e7c7a424a9f76d1224cbdbbe58374229b68
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/proxyv2:1.4.5
+        URL: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
   labels:
     app: galley
     istio: galley
@@ -5686,7 +5706,7 @@ spec:
         - --monitoringPort=15014
         - --validation-port=9443
         - --log_output_level=default:info
-        image: docker.io/istio/galley:1.4.5
+        image: index.docker.io/istio/galley@sha256:26e744bdfd3db289d4cfc9be63e38e7c7a424a9f76d1224cbdbbe58374229b68
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -5752,7 +5772,7 @@ spec:
               fieldPath: status.podIP
         - name: SDS_ENABLED
           value: "false"
-        image: docker.io/istio/proxyv2:1.4.5
+        image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -5788,57 +5808,69 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-galley
-  namespace: istio-system
-  labels:
-    app: galley
-    release: istio
-    istio: galley
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: galley
+    istio: galley
+    release: istio
+  name: istio-galley
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: galley
-      release: istio
       istio: galley
+      release: istio
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-galley
-  namespace: istio-system
   labels:
     app: galley
     istio: galley
     release: istio
+  name: istio-galley
+  namespace: istio-system
 spec:
   ports:
-  - port: 443
-    name: https-validation
+  - name: https-validation
+    port: 443
     targetPort: 9443
-  - port: 15014
-    name: http-monitoring
-  - port: 9901
-    name: grpc-mcp
-  - port: 15019
-    name: grpc-tls-mcp
+  - name: http-monitoring
+    port: 15014
+  - name: grpc-mcp
+    port: 9901
+  - name: grpc-tls-mcp
+    port: 15019
   selector:
     istio: galley
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-galley-service-account
-  namespace: istio-system
   labels:
     app: galley
     release: istio
+  name: istio-galley-service-account
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/node-agent-k8s:1.4.5
+        URL: index.docker.io/istio/node-agent-k8s@sha256:7e17ab509777a54f3c0dfb4518692a9ca179d1e8c41df87dc81a734339b37152
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/proxyv2:1.4.5
+        URL: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
   labels:
     app: istio-ingressgateway
     istio: ingressgateway
@@ -5905,7 +5937,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: docker.io/istio/node-agent-k8s:1.4.5
+        image: index.docker.io/istio/node-agent-k8s@sha256:7e17ab509777a54f3c0dfb4518692a9ca179d1e8c41df87dc81a734339b37152
         imagePullPolicy: IfNotPresent
         name: ingress-sds
         resources:
@@ -6001,7 +6033,7 @@ spec:
           value: Kubernetes
         - name: SDS_ENABLED
           value: "false"
-        image: docker.io/istio/proxyv2:1.4.5
+        image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -6073,47 +6105,47 @@ spec:
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: ingressgateway
-  namespace: istio-system
   labels:
     release: istio
+  name: ingressgateway
+  namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
   servers:
-  - port:
-      number: 80
-      name: http
-      protocol: HTTP
-    hosts:
+  - hosts:
     - '*'
+    port:
+      name: http
+      number: 80
+      protocol: HTTP
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: ingressgateway
-  namespace: istio-system
-  labels:
-    app: istio-ingressgateway
-    release: istio
-    istio: ingressgateway
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: istio-ingressgateway
+    istio: ingressgateway
+    release: istio
+  name: ingressgateway
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: istio-ingressgateway
-      release: istio
       istio: ingressgateway
+      release: istio
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: istio-ingressgateway-sds
-  namespace: istio-system
   labels:
     release: istio
+  name: istio-ingressgateway-sds
+  namespace: istio-system
 rules:
 - apiGroups:
   - ""
@@ -6127,10 +6159,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: istio-ingressgateway-sds
-  namespace: istio-system
   labels:
     release: istio
+  name: istio-ingressgateway-sds
+  namespace: istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -6142,18 +6174,15 @@ subjects:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-ingressgateway
-  namespace: istio-system
   annotations: null
   labels:
     app: istio-ingressgateway
-    release: istio
     istio: ingressgateway
+    release: istio
+  name: istio-ingressgateway
+  namespace: istio-system
 spec:
   externalTrafficPolicy: Local
-  type: LoadBalancer
-  selector:
-    app: istio-ingressgateway
   ports:
   - name: status-port
     port: 15020
@@ -6178,23 +6207,26 @@ spec:
   - name: tls
     port: 15443
     targetPort: 15443
+  selector:
+    app: istio-ingressgateway
+  type: LoadBalancer
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-ingressgateway-service-account
-  namespace: istio-system
   labels:
     app: istio-ingressgateway
     release: istio
+  name: istio-ingressgateway-service-account
+  namespace: istio-system
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar
 metadata:
-  name: default
-  namespace: istio-system
   labels:
     release: istio
+  name: default
+  namespace: istio-system
 spec:
   egress:
   - hosts:
@@ -6203,29 +6235,29 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-sidecar-injector-istio-system
   labels:
     app: sidecar-injector
-    release: istio
     istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector-istio-system
 rules:
 - apiGroups:
   - ""
-  resources:
-  - configmaps
   resourceNames:
   - istio-sidecar-injector
+  resources:
+  - configmaps
   verbs:
   - get
   - list
   - watch
 - apiGroups:
   - admissionregistration.k8s.io
-  resources:
-  - mutatingwebhookconfigurations
   resourceNames:
   - istio-sidecar-injector
   - istio-sidecar-injector-istio-system
+  resources:
+  - mutatingwebhookconfigurations
   verbs:
   - get
   - list
@@ -6235,11 +6267,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-sidecar-injector-admin-role-binding-istio-system
   labels:
     app: sidecar-injector
-    release: istio
     istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector-admin-role-binding-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -6250,12 +6282,6 @@ subjects:
   namespace: istio-system
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: injector-mesh
-  namespace: istio-system
-  labels:
-    release: istio
 data:
   mesh: |-
     # Unix Domain Socket through which envoy communicates with NodeAgent SDS to get
@@ -6299,10 +6325,23 @@ data:
       #
       # Address where istio Pilot service is running
       discoveryAddress: istio-pilot.istio-system:15011
+kind: ConfigMap
+metadata:
+  labels:
+    release: istio
+  name: injector-mesh
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/sidecar_injector:1.4.5
+        URL: index.docker.io/istio/sidecar_injector@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
   labels:
     app: sidecarInjectorWebhook
     istio: sidecar-injector
@@ -6375,7 +6414,7 @@ spec:
         - --reconcileWebhookConfig=true
         - --webhookConfigName=istio-sidecar-injector
         - --log_output_level=debug
-        image: docker.io/istio/sidecar_injector:1.4.5
+        image: index.docker.io/istio/sidecar_injector@sha256:ba446f8cf98bafdad4514fd492432dd180243cbc55a0b9c6bebfe31cb169033d
         imagePullPolicy: IfNotPresent
         livenessProbe:
           exec:
@@ -6429,59 +6468,59 @@ spec:
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
-  name: istio-sidecar-injector
   labels:
     app: sidecar-injector
     release: istio
+  name: istio-sidecar-injector
 webhooks:
-- name: sidecar-injector.istio.io
-  clientConfig:
+- clientConfig:
     service:
       name: istio-sidecar-injector
       namespace: istio-system
       path: /inject
-  rules:
-  - operations:
-    - CREATE
-    apiGroups:
-    - ""
-    apiVersions:
-    - v1
-    resources:
-    - pods
   failurePolicy: Fail
+  name: sidecar-injector.istio.io
   namespaceSelector:
     matchLabels:
       istio-injection: enabled
+  rules:
+  - apiGroups:
+    - ""
+    apiVersions:
+    - v1
+    operations:
+    - CREATE
+    resources:
+    - pods
 ---
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
-  labels:
-    app: sidecar-injector
-    release: istio
-    istio: sidecar-injector
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: sidecar-injector
+    istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: sidecar-injector
-      release: istio
       istio: sidecar-injector
+      release: istio
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    release: istio
     istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 spec:
   ports:
   - port: 443
@@ -6492,40 +6531,15 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-sidecar-injector-service-account
-  namespace: istio-system
   labels:
     app: sidecarInjectorWebhook
-    release: istio
     istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector-service-account
+  namespace: istio-system
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: istio-sidecar-injector
-  namespace: istio-system
-  labels:
-    release: istio
-    app: sidecar-injector
-    istio: sidecar-injector
 data:
-  values: '{"certmanager":{"enabled":false,"hub":"quay.io/jetstack","image":"cert-manager-controller","namespace":"istio-system","tag":"v0.6.2"},"clusterResources":true,"cni":{"namespace":"istio-system"},"galley":{"enableAnalysis":false,"enabled":true,"image":"galley","namespace":"istio-system"},"gateways":{"istio-egressgateway":{"autoscaleEnabled":true,"enabled":false,"env":{"ISTIO_META_ROUTER_MODE":"sni-dnat"},"namespace":"istio-system","ports":[{"name":"http2","port":80},{"name":"https","port":443},{"name":"tls","port":15443,"targetPort":15443}],"secretVolumes":[{"mountPath":"/etc/istio/egressgateway-certs","name":"egressgateway-certs","secretName":"istio-egressgateway-certs"},{"mountPath":"/etc/istio/egressgateway-ca-certs","name":"egressgateway-ca-certs","secretName":"istio-egressgateway-ca-certs"}],"type":"ClusterIP","zvpn":{"enabled":true,"suffix":"global"}},"istio-ingressgateway":{"applicationPorts":"","autoscaleEnabled":false,"debug":"info","domain":"","enabled":true,"env":{"ISTIO_META_ROUTER_MODE":"sni-dnat"},"externalTrafficPolicy":"Local","meshExpansionPorts":[{"name":"tcp-pilot-grpc-tls","port":15011,"targetPort":15011},{"name":"tcp-citadel-grpc-tls","port":8060,"targetPort":8060},{"name":"tcp-dns-tls","port":853,"targetPort":853}],"namespace":"istio-system","ports":[{"name":"status-port","port":15020,"targetPort":15020},{"name":"http2","port":80,"targetPort":80},{"name":"https","port":443},{"name":"kiali","port":15029,"targetPort":15029},{"name":"prometheus","port":15030,"targetPort":15030},{"name":"grafana","port":15031,"targetPort":15031},{"name":"tracing","port":15032,"targetPort":15032},{"name":"tls","port":15443,"targetPort":15443}],"sds":{"enabled":true,"image":"node-agent-k8s","resources":{"limits":{"cpu":"2000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"secretVolumes":[{"mountPath":"/etc/istio/ingressgateway-certs","name":"ingressgateway-certs","secretName":"istio-ingressgateway-certs"},{"mountPath":"/etc/istio/ingressgateway-ca-certs","name":"ingressgateway-ca-certs","secretName":"istio-ingressgateway-ca-certs"}],"type":"LoadBalancer","zvpn":{"enabled":true,"suffix":"global"}}},"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"certificates":[],"configNamespace":"istio-system","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":true},"defaultResources":{"requests":{"cpu":"10m"}},"disablePolicyChecks":true,"enableHelmTest":false,"enableTracing":true,"enabled":true,"hub":"docker.io/istio","imagePullPolicy":"IfNotPresent","imagePullSecrets":[],"istioNamespace":"istio-system","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{"enabled":true},"logAsJson":false,"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"auto":true,"enabled":false},"multiCluster":{"clusterName":"","enabled":false},"namespace":"istio-system","network":"","omitSidecarInjectorConfigMap":false,"oneNamespace":false,"operatorManageWebhooks":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-system","priorityClassName":"","prometheusNamespace":"istio-system","proxy":{"accessLogEncoding":"JSON","accessLogFile":"/dev/stdout","accessLogFormat":"{\n  \"app_id\":
-    \"%REQ(CF-APP-ID)%\",\n  \"authority\": \"%REQ(:AUTHORITY)%\",\n  \"bytes_received\":
-    \"%BYTES_RECEIVED%\",\n  \"bytes_sent\": \"%BYTES_SENT%\",\n  \"downstream_local_address\":
-    \"%DOWNSTREAM_LOCAL_ADDRESS%\",\n  \"downstream_remote_address\": \"%DOWNSTREAM_REMOTE_ADDRESS%\",\n  \"duration\":
-    \"%DURATION%\",\n  \"method\": \"%REQ(:METHOD)%\",\n  \"organization_id\": \"%REQ(CF-ORGANIZATION-ID)%\",\n  \"path\":
-    \"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\n  \"process_type\": \"%REQ(APP-PROCESS-TYPE)%\",\n  \"protocol\":
-    \"%PROTOCOL%\",\n  \"referer\": \"%REQ(REFERER)%\",\n  \"request_id\": \"%REQ(X-REQUEST-ID)%\",\n  \"requested_server_name\":
-    \"%REQUESTED_SERVER_NAME%\",\n  \"response_code\": \"%RESPONSE_CODE%\",\n  \"response_duration\":
-    \"%RESPONSE_DURATION%\",\n  \"response_flags\": \"%RESPONSE_FLAGS%\",\n  \"response_tx_duration\":
-    \"%RESPONSE_TX_DURATION%\",\n  \"space_id\": \"%REQ(CF-SPACE-ID)%\",\n  \"start_time\":
-    \"%START_TIME%\",\n  \"upstream_cluster\": \"%UPSTREAM_CLUSTER%\",\n  \"upstream_host\":
-    \"%UPSTREAM_HOST%\",\n  \"upstream_local_address\": \"%UPSTREAM_LOCAL_ADDRESS%\",\n  \"upstream_service_time\":
-    \"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\n  \"upstream_transport_failure_reason\":
-    \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\",\n  \"user_agent\": \"%REQ(USER-AGENT)%\",\n  \"x_b3_parentspanid\":
-    \"%REQ(X-B3-PARENTSPANID)%\",\n  \"x_b3_spanid\": \"%REQ(X-B3-SPANID)%\",\n  \"x_b3_traceid\":
-    \"%REQ(X-B3-TRACEID)%\",\n  \"x_forwarded_for\": \"%REQ(X-FORWARDED-FOR)%\",\n  \"x_forwarded_proto\":
-    \"%REQ(X-FORWARDED-PROTO)%\"\n}","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyAccessLogService":{"enabled":false},"envoyMetricsService":{"enabled":false,"tcpKeepalive":{"interval":"10s","probes":3,"time":"10s"},"tlsSettings":{"mode":"DISABLE","subjectAltNames":[]}},"envoyStatsd":{"enabled":false},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"protocolDetectionTimeout":"100ms","readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxyv2","resources":{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"10Mi"}}},"sds":{"enabled":false,"token":{"aud":"istio-ca"},"udsPath":""},"securityNamespace":"istio-system","tag":"1.4.5","telemetryNamespace":"istio-system","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"cluster.local","useMCP":true},"grafana":{"accessMode":"ReadWriteMany","contextPath":"/grafana","dashboardProviders":{"dashboardproviders.yaml":{"apiVersion":1,"providers":[{"disableDeletion":false,"folder":"istio","name":"istio","options":{"path":"/var/lib/grafana/dashboards/istio"},"orgId":1,"type":"file"}]}},"datasources":{"datasources.yaml":{"apiVersion":1}},"enabled":false,"env":{},"envSecrets":{},"image":{"repository":"grafana/grafana","tag":"6.4.3"},"ingress":{"enabled":false,"hosts":["grafana.local"]},"namespace":"istio-system","nodeSelector":{},"persist":false,"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"security":{"enabled":false,"passphraseKey":"passphrase","secretName":"grafana","usernameKey":"username"},"service":{"annotations":{},"externalPort":3000,"name":"http","type":"ClusterIP"},"storageClassName":"","tolerations":[]},"istio_cni":{"enabled":false,"repair":{"enabled":true}},"istiocoredns":{"coreDNSImage":"coredns/coredns","coreDNSPluginImage":"istio/coredns-plugin:0.2-istio-1.1","coreDNSTag":"1.6.2","enabled":false,"namespace":"istio-system"},"kiali":{"contextPath":"/kiali","createDemoSecret":false,"dashboard":{"passphraseKey":"passphrase","secretName":"kiali","usernameKey":"username","viewOnlyMode":false},"enabled":false,"hub":"quay.io/kiali","ingress":{"enabled":false,"hosts":["kiali.local"]},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"security":{"cert_file":"/kiali-cert/cert-chain.pem","enabled":false,"private_key_file":"/kiali-cert/key.pem"},"tag":"v1.9"},"mixer":{"adapters":{"kubernetesenv":{"enabled":true},"prometheus":{"enabled":true,"metricsExpiryDuration":"10m"},"stackdriver":{"auth":{"apiKey":"","appCredentials":false,"serviceAccountPath":""},"enabled":false,"tracer":{"enabled":false,"sampleProbability":1}},"stdio":{"enabled":false,"outputAsJson":false},"useAdapterCRDs":false},"policy":{"adapters":{"kubernetesenv":{"enabled":true},"useAdapterCRDs":false},"autoscaleEnabled":true,"enabled":true,"image":"mixer","namespace":"istio-system","sessionAffinityEnabled":false},"telemetry":{"autoscaleEnabled":true,"enabled":true,"env":{"GOMAXPROCS":"6"},"image":"mixer","loadshedding":{"latencyThreshold":"100ms","mode":"enforce"},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"reportBatchMaxEntries":100,"reportBatchMaxTime":"1s","sessionAffinityEnabled":false,"tolerations":[],"useMCP":true}},"nodeagent":{"enabled":false,"image":"node-agent-k8s","namespace":"istio-system"},"pilot":{"appNamespaces":[],"autoscaleEnabled":true,"autoscaleMax":5,"autoscaleMin":1,"configMap":true,"configNamespace":"istio-config","cpu":{"targetAverageUtilization":80},"enableProtocolSniffingForInbound":false,"enableProtocolSniffingForOutbound":true,"enabled":true,"env":{},"image":"pilot","ingress":{"ingressClass":"istio","ingressControllerMode":"OFF","ingressService":"istio-ingressgateway"},"keepaliveMaxServerConnectionAge":"30m","meshNetworks":{"networks":{}},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"policy":{"enabled":false},"replicaCount":1,"tolerations":[],"traceSampling":1,"useMCP":true},"prometheus":{"contextPath":"/prometheus","enabled":false,"hub":"docker.io/prom","ingress":{"enabled":false,"hosts":["prometheus.local"]},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"retention":"6h","scrapeInterval":"15s","security":{"enabled":true},"tag":"v2.12.0","tolerations":[]},"security":{"dnsCerts":{"istio-pilot-service-account.istio-control":"istio-pilot.istio-control"},"enableNamespacesByDefault":true,"enabled":true,"image":"citadel","namespace":"istio-system","selfSigned":true,"trustDomain":"cluster.local"},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":false,"enabled":true,"image":"sidecar_injector","injectLabel":"istio-injection","injectedAnnotations":{},"lifecycle":{},"namespace":"istio-system","neverInjectSelector":[],"nodeSelector":{},"objectSelector":{"autoInject":true,"enabled":false},"podAnnotations":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"resources":{},"rewriteAppHTTPProbe":true,"rollingMaxSurge":"100%","rollingMaxUnavailable":"25%","selfSigned":false,"tolerations":[]},"telemetry":{"enabled":true,"v1":{"enabled":true},"v2":{"enabled":false,"prometheus":{"enabled":true},"stackdriver":{"configOverride":{},"enabled":false,"logging":false,"monitoring":false,"topology":false}}},"tracing":{"enabled":false,"ingress":{"enabled":false},"jaeger":{"accessMode":"ReadWriteMany","enabled":false,"hub":"docker.io/jaegertracing","memory":{"max_traces":50000},"namespace":"istio-system","persist":false,"spanStorageType":"badger","storageClassName":"","tag":"1.14"},"nodeSelector":{},"opencensus":{"exporters":{"stackdriver":{"enable_tracing":true}},"hub":"docker.io/omnition","resources":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"200m","memory":"400Mi"}},"tag":"0.1.9"},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"provider":"jaeger","service":{"annotations":{},"externalPort":9411,"name":"http-query","type":"ClusterIP"},"zipkin":{"hub":"docker.io/openzipkin","javaOptsHeap":700,"maxSpans":500000,"node":{"cpus":2},"probeStartupDelay":200,"queryPort":9411,"resources":{"limits":{"cpu":"300m","memory":"900Mi"},"requests":{"cpu":"150m","memory":"900Mi"}},"tag":"2.14.2"}},"version":""}'
   config: |-
     policy: enabled
     alwaysInjectSelector:
@@ -6973,6 +6987,31 @@ data:
           {{- end }}
       {{- end }}
     injectedAnnotations:
+  values: '{"certmanager":{"enabled":false,"hub":"quay.io/jetstack","image":"cert-manager-controller","namespace":"istio-system","tag":"v0.6.2"},"clusterResources":true,"cni":{"namespace":"istio-system"},"galley":{"enableAnalysis":false,"enabled":true,"image":"galley","namespace":"istio-system"},"gateways":{"istio-egressgateway":{"autoscaleEnabled":true,"enabled":false,"env":{"ISTIO_META_ROUTER_MODE":"sni-dnat"},"namespace":"istio-system","ports":[{"name":"http2","port":80},{"name":"https","port":443},{"name":"tls","port":15443,"targetPort":15443}],"secretVolumes":[{"mountPath":"/etc/istio/egressgateway-certs","name":"egressgateway-certs","secretName":"istio-egressgateway-certs"},{"mountPath":"/etc/istio/egressgateway-ca-certs","name":"egressgateway-ca-certs","secretName":"istio-egressgateway-ca-certs"}],"type":"ClusterIP","zvpn":{"enabled":true,"suffix":"global"}},"istio-ingressgateway":{"applicationPorts":"","autoscaleEnabled":false,"debug":"info","domain":"","enabled":true,"env":{"ISTIO_META_ROUTER_MODE":"sni-dnat"},"externalTrafficPolicy":"Local","meshExpansionPorts":[{"name":"tcp-pilot-grpc-tls","port":15011,"targetPort":15011},{"name":"tcp-citadel-grpc-tls","port":8060,"targetPort":8060},{"name":"tcp-dns-tls","port":853,"targetPort":853}],"namespace":"istio-system","ports":[{"name":"status-port","port":15020,"targetPort":15020},{"name":"http2","port":80,"targetPort":80},{"name":"https","port":443},{"name":"kiali","port":15029,"targetPort":15029},{"name":"prometheus","port":15030,"targetPort":15030},{"name":"grafana","port":15031,"targetPort":15031},{"name":"tracing","port":15032,"targetPort":15032},{"name":"tls","port":15443,"targetPort":15443}],"sds":{"enabled":true,"image":"node-agent-k8s","resources":{"limits":{"cpu":"2000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}},"secretVolumes":[{"mountPath":"/etc/istio/ingressgateway-certs","name":"ingressgateway-certs","secretName":"istio-ingressgateway-certs"},{"mountPath":"/etc/istio/ingressgateway-ca-certs","name":"ingressgateway-ca-certs","secretName":"istio-ingressgateway-ca-certs"}],"type":"LoadBalancer","zvpn":{"enabled":true,"suffix":"global"}}},"global":{"arch":{"amd64":2,"ppc64le":2,"s390x":2},"certificates":[],"configNamespace":"istio-system","configValidation":true,"controlPlaneSecurityEnabled":true,"defaultNodeSelector":{},"defaultPodDisruptionBudget":{"enabled":true},"defaultResources":{"requests":{"cpu":"10m"}},"disablePolicyChecks":true,"enableHelmTest":false,"enableTracing":true,"enabled":true,"hub":"docker.io/istio","imagePullPolicy":"IfNotPresent","imagePullSecrets":[],"istioNamespace":"istio-system","k8sIngress":{"enableHttps":false,"enabled":false,"gatewayName":"ingressgateway"},"localityLbSetting":{"enabled":true},"logAsJson":false,"logging":{"level":"default:info"},"meshExpansion":{"enabled":false,"useILB":false},"meshNetworks":{},"mtls":{"auto":true,"enabled":false},"multiCluster":{"clusterName":"","enabled":false},"namespace":"istio-system","network":"","omitSidecarInjectorConfigMap":false,"oneNamespace":false,"operatorManageWebhooks":false,"outboundTrafficPolicy":{"mode":"ALLOW_ANY"},"policyCheckFailOpen":false,"policyNamespace":"istio-system","priorityClassName":"","prometheusNamespace":"istio-system","proxy":{"accessLogEncoding":"JSON","accessLogFile":"/dev/stdout","accessLogFormat":"{\n  \"app_id\":
+    \"%REQ(CF-APP-ID)%\",\n  \"authority\": \"%REQ(:AUTHORITY)%\",\n  \"bytes_received\":
+    \"%BYTES_RECEIVED%\",\n  \"bytes_sent\": \"%BYTES_SENT%\",\n  \"downstream_local_address\":
+    \"%DOWNSTREAM_LOCAL_ADDRESS%\",\n  \"downstream_remote_address\": \"%DOWNSTREAM_REMOTE_ADDRESS%\",\n  \"duration\":
+    \"%DURATION%\",\n  \"method\": \"%REQ(:METHOD)%\",\n  \"organization_id\": \"%REQ(CF-ORGANIZATION-ID)%\",\n  \"path\":
+    \"%REQ(X-ENVOY-ORIGINAL-PATH?:PATH)%\",\n  \"process_type\": \"%REQ(APP-PROCESS-TYPE)%\",\n  \"protocol\":
+    \"%PROTOCOL%\",\n  \"referer\": \"%REQ(REFERER)%\",\n  \"request_id\": \"%REQ(X-REQUEST-ID)%\",\n  \"requested_server_name\":
+    \"%REQUESTED_SERVER_NAME%\",\n  \"response_code\": \"%RESPONSE_CODE%\",\n  \"response_duration\":
+    \"%RESPONSE_DURATION%\",\n  \"response_flags\": \"%RESPONSE_FLAGS%\",\n  \"response_tx_duration\":
+    \"%RESPONSE_TX_DURATION%\",\n  \"space_id\": \"%REQ(CF-SPACE-ID)%\",\n  \"start_time\":
+    \"%START_TIME%\",\n  \"upstream_cluster\": \"%UPSTREAM_CLUSTER%\",\n  \"upstream_host\":
+    \"%UPSTREAM_HOST%\",\n  \"upstream_local_address\": \"%UPSTREAM_LOCAL_ADDRESS%\",\n  \"upstream_service_time\":
+    \"%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%\",\n  \"upstream_transport_failure_reason\":
+    \"%UPSTREAM_TRANSPORT_FAILURE_REASON%\",\n  \"user_agent\": \"%REQ(USER-AGENT)%\",\n  \"x_b3_parentspanid\":
+    \"%REQ(X-B3-PARENTSPANID)%\",\n  \"x_b3_spanid\": \"%REQ(X-B3-SPANID)%\",\n  \"x_b3_traceid\":
+    \"%REQ(X-B3-TRACEID)%\",\n  \"x_forwarded_for\": \"%REQ(X-FORWARDED-FOR)%\",\n  \"x_forwarded_proto\":
+    \"%REQ(X-FORWARDED-PROTO)%\"\n}","autoInject":"enabled","clusterDomain":"cluster.local","componentLogLevel":"misc:error","concurrency":2,"dnsRefreshRate":"300s","enableCoreDump":false,"envoyAccessLogService":{"enabled":false},"envoyMetricsService":{"enabled":false,"tcpKeepalive":{"interval":"10s","probes":3,"time":"10s"},"tlsSettings":{"mode":"DISABLE","subjectAltNames":[]}},"envoyStatsd":{"enabled":false},"excludeIPRanges":"","excludeInboundPorts":"","excludeOutboundPorts":"","image":"proxyv2","includeIPRanges":"*","includeInboundPorts":"*","kubevirtInterfaces":"","logLevel":"warning","privileged":false,"protocolDetectionTimeout":"100ms","readinessFailureThreshold":30,"readinessInitialDelaySeconds":1,"readinessPeriodSeconds":2,"resources":{"limits":{"cpu":"2000m","memory":"1024Mi"},"requests":{"cpu":"100m","memory":"128Mi"}},"statusPort":15020,"tracer":"zipkin"},"proxy_init":{"image":"proxyv2","resources":{"limits":{"cpu":"100m","memory":"50Mi"},"requests":{"cpu":"10m","memory":"10Mi"}}},"sds":{"enabled":false,"token":{"aud":"istio-ca"},"udsPath":""},"securityNamespace":"istio-system","tag":"1.4.5","telemetryNamespace":"istio-system","tracer":{"datadog":{"address":"$(HOST_IP):8126"},"lightstep":{"accessToken":"","address":"","cacertPath":"","secure":true},"zipkin":{"address":""}},"trustDomain":"cluster.local","useMCP":true},"grafana":{"accessMode":"ReadWriteMany","contextPath":"/grafana","dashboardProviders":{"dashboardproviders.yaml":{"apiVersion":1,"providers":[{"disableDeletion":false,"folder":"istio","name":"istio","options":{"path":"/var/lib/grafana/dashboards/istio"},"orgId":1,"type":"file"}]}},"datasources":{"datasources.yaml":{"apiVersion":1}},"enabled":false,"env":{},"envSecrets":{},"image":{"repository":"grafana/grafana","tag":"6.4.3"},"ingress":{"enabled":false,"hosts":["grafana.local"]},"namespace":"istio-system","nodeSelector":{},"persist":false,"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"security":{"enabled":false,"passphraseKey":"passphrase","secretName":"grafana","usernameKey":"username"},"service":{"annotations":{},"externalPort":3000,"name":"http","type":"ClusterIP"},"storageClassName":"","tolerations":[]},"istio_cni":{"enabled":false,"repair":{"enabled":true}},"istiocoredns":{"coreDNSImage":"coredns/coredns","coreDNSPluginImage":"istio/coredns-plugin:0.2-istio-1.1","coreDNSTag":"1.6.2","enabled":false,"namespace":"istio-system"},"kiali":{"contextPath":"/kiali","createDemoSecret":false,"dashboard":{"passphraseKey":"passphrase","secretName":"kiali","usernameKey":"username","viewOnlyMode":false},"enabled":false,"hub":"quay.io/kiali","ingress":{"enabled":false,"hosts":["kiali.local"]},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"security":{"cert_file":"/kiali-cert/cert-chain.pem","enabled":false,"private_key_file":"/kiali-cert/key.pem"},"tag":"v1.9"},"mixer":{"adapters":{"kubernetesenv":{"enabled":true},"prometheus":{"enabled":true,"metricsExpiryDuration":"10m"},"stackdriver":{"auth":{"apiKey":"","appCredentials":false,"serviceAccountPath":""},"enabled":false,"tracer":{"enabled":false,"sampleProbability":1}},"stdio":{"enabled":false,"outputAsJson":false},"useAdapterCRDs":false},"policy":{"adapters":{"kubernetesenv":{"enabled":true},"useAdapterCRDs":false},"autoscaleEnabled":true,"enabled":true,"image":"mixer","namespace":"istio-system","sessionAffinityEnabled":false},"telemetry":{"autoscaleEnabled":true,"enabled":true,"env":{"GOMAXPROCS":"6"},"image":"mixer","loadshedding":{"latencyThreshold":"100ms","mode":"enforce"},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"reportBatchMaxEntries":100,"reportBatchMaxTime":"1s","sessionAffinityEnabled":false,"tolerations":[],"useMCP":true}},"nodeagent":{"enabled":false,"image":"node-agent-k8s","namespace":"istio-system"},"pilot":{"appNamespaces":[],"autoscaleEnabled":true,"autoscaleMax":5,"autoscaleMin":1,"configMap":true,"configNamespace":"istio-config","cpu":{"targetAverageUtilization":80},"enableProtocolSniffingForInbound":false,"enableProtocolSniffingForOutbound":true,"enabled":true,"env":{},"image":"pilot","ingress":{"ingressClass":"istio","ingressControllerMode":"OFF","ingressService":"istio-ingressgateway"},"keepaliveMaxServerConnectionAge":"30m","meshNetworks":{"networks":{}},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"policy":{"enabled":false},"replicaCount":1,"tolerations":[],"traceSampling":1,"useMCP":true},"prometheus":{"contextPath":"/prometheus","enabled":false,"hub":"docker.io/prom","ingress":{"enabled":false,"hosts":["prometheus.local"]},"namespace":"istio-system","nodeSelector":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"retention":"6h","scrapeInterval":"15s","security":{"enabled":true},"tag":"v2.12.0","tolerations":[]},"security":{"dnsCerts":{"istio-pilot-service-account.istio-control":"istio-pilot.istio-control"},"enableNamespacesByDefault":true,"enabled":true,"image":"citadel","namespace":"istio-system","selfSigned":true,"trustDomain":"cluster.local"},"sidecarInjectorWebhook":{"alwaysInjectSelector":[],"enableNamespacesByDefault":false,"enabled":true,"image":"sidecar_injector","injectLabel":"istio-injection","injectedAnnotations":{},"lifecycle":{},"namespace":"istio-system","neverInjectSelector":[],"nodeSelector":{},"objectSelector":{"autoInject":true,"enabled":false},"podAnnotations":{},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"replicaCount":1,"resources":{},"rewriteAppHTTPProbe":true,"rollingMaxSurge":"100%","rollingMaxUnavailable":"25%","selfSigned":false,"tolerations":[]},"telemetry":{"enabled":true,"v1":{"enabled":true},"v2":{"enabled":false,"prometheus":{"enabled":true},"stackdriver":{"configOverride":{},"enabled":false,"logging":false,"monitoring":false,"topology":false}}},"tracing":{"enabled":false,"ingress":{"enabled":false},"jaeger":{"accessMode":"ReadWriteMany","enabled":false,"hub":"docker.io/jaegertracing","memory":{"max_traces":50000},"namespace":"istio-system","persist":false,"spanStorageType":"badger","storageClassName":"","tag":"1.14"},"nodeSelector":{},"opencensus":{"exporters":{"stackdriver":{"enable_tracing":true}},"hub":"docker.io/omnition","resources":{"limits":{"cpu":"1","memory":"2Gi"},"requests":{"cpu":"200m","memory":"400Mi"}},"tag":"0.1.9"},"podAntiAffinityLabelSelector":[],"podAntiAffinityTermLabelSelector":[],"provider":"jaeger","service":{"annotations":{},"externalPort":9411,"name":"http-query","type":"ClusterIP"},"zipkin":{"hub":"docker.io/openzipkin","javaOptsHeap":700,"maxSpans":500000,"node":{"cpus":2},"probeStartupDelay":200,"queryPort":9411,"resources":{"limits":{"cpu":"300m","memory":"900Mi"},"requests":{"cpu":"150m","memory":"900Mi"}},"tag":"2.14.2"}},"version":""}'
+kind: ConfigMap
+metadata:
+  labels:
+    app: sidecar-injector
+    istio: sidecar-injector
+    release: istio
+  name: istio-sidecar-injector
+  namespace: istio-system
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -6998,10 +7037,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-pilot-istio-system
   labels:
     app: pilot
     release: istio
+  name: istio-pilot-istio-system
 rules:
 - apiGroups:
   - config.istio.io
@@ -7099,10 +7138,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-pilot-istio-system
   labels:
     app: pilot
     release: istio
+  name: istio-pilot-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -7113,12 +7152,6 @@ subjects:
   namespace: istio-system
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: pilot-envoy-config
-  labels:
-    release: istio
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -7273,57 +7306,15 @@ data:
                             route:
                               cluster: out.galley.15019
                               timeout: 0.000s
----
-apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: istio
-  namespace: istio-system
   labels:
     release: istio
+  name: pilot-envoy-config
+  namespace: istio-system
+---
+apiVersion: v1
 data:
-  meshNetworks: |-
-    # Network config
-    networks: {}
-  values.yaml: |-
-    appNamespaces: []
-    autoscaleEnabled: true
-    autoscaleMax: 5
-    autoscaleMin: 1
-    configMap: true
-    configNamespace: istio-config
-    cpu:
-      targetAverageUtilization: 80
-    enableProtocolSniffingForInbound: false
-    enableProtocolSniffingForOutbound: true
-    enabled: true
-    env: {}
-    image: pilot
-    ingress:
-      ingressClass: istio
-      ingressControllerMode: "OFF"
-      ingressService: istio-ingressgateway
-    keepaliveMaxServerConnectionAge: 30m
-    meshNetworks:
-      networks: {}
-    namespace: istio-system
-    nodeSelector: {}
-    plugins: []
-    podAnnotations: {}
-    podAntiAffinityLabelSelector: []
-    podAntiAffinityTermLabelSelector: []
-    policy:
-      enabled: false
-    replicaCount: 1
-    resources:
-      requests:
-        cpu: 500m
-        memory: 2048Mi
-    rollingMaxSurge: 100%
-    rollingMaxUnavailable: 25%
-    tolerations: []
-    traceSampling: 1
-    useMCP: true
   mesh: |-
     # Set enableTracing to false to disable request tracing.
     enableTracing: true
@@ -7451,10 +7442,70 @@ data:
       #
       # Address where istio Pilot service is running
       discoveryAddress: istio-pilot.istio-system:15011
+  meshNetworks: |-
+    # Network config
+    networks: {}
+  values.yaml: |-
+    appNamespaces: []
+    autoscaleEnabled: true
+    autoscaleMax: 5
+    autoscaleMin: 1
+    configMap: true
+    configNamespace: istio-config
+    cpu:
+      targetAverageUtilization: 80
+    enableProtocolSniffingForInbound: false
+    enableProtocolSniffingForOutbound: true
+    enabled: true
+    env: {}
+    image: pilot
+    ingress:
+      ingressClass: istio
+      ingressControllerMode: "OFF"
+      ingressService: istio-ingressgateway
+    keepaliveMaxServerConnectionAge: 30m
+    meshNetworks:
+      networks: {}
+    namespace: istio-system
+    nodeSelector: {}
+    plugins: []
+    podAnnotations: {}
+    podAntiAffinityLabelSelector: []
+    podAntiAffinityTermLabelSelector: []
+    policy:
+      enabled: false
+    replicaCount: 1
+    resources:
+      requests:
+        cpu: 500m
+        memory: 2048Mi
+    rollingMaxSurge: 100%
+    rollingMaxUnavailable: 25%
+    tolerations: []
+    traceSampling: 1
+    useMCP: true
+kind: ConfigMap
+metadata:
+  labels:
+    release: istio
+  name: istio
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/pilot:1.4.5
+        URL: index.docker.io/istio/pilot@sha256:2bca5900d6bf20d5f0bf2b6673bc4d2885bab8cca2a9060336a0024930665b59
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/proxyv2:1.4.5
+        URL: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
   labels:
     app: pilot
     istio: pilot
@@ -7544,7 +7595,7 @@ spec:
           value: "true"
         - name: PILOT_ENABLE_PROTOCOL_SNIFFING_FOR_INBOUND
           value: "false"
-        image: docker.io/istio/pilot:1.4.5
+        image: index.docker.io/istio/pilot@sha256:2bca5900d6bf20d5f0bf2b6673bc4d2885bab8cca2a9060336a0024930665b59
         imagePullPolicy: IfNotPresent
         name: discovery
         ports:
@@ -7593,7 +7644,7 @@ spec:
               fieldPath: status.podIP
         - name: SDS_ENABLED
           value: "false"
-        image: docker.io/istio/proxyv2:1.4.5
+        image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -7627,9 +7678,9 @@ spec:
 apiVersion: authentication.istio.io/v1alpha1
 kind: MeshPolicy
 metadata:
-  name: default
   labels:
     release: istio
+  name: default
 spec:
   peers:
   - mtls:
@@ -7638,52 +7689,52 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-pilot
-  namespace: istio-system
-  labels:
-    app: pilot
-    release: istio
-    istio: pilot
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: pilot
+    istio: pilot
+    release: istio
+  name: istio-pilot
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: pilot
-      release: istio
       istio: pilot
+      release: istio
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-pilot
-  namespace: istio-system
   labels:
     app: pilot
-    release: istio
     istio: pilot
+    release: istio
+  name: istio-pilot
+  namespace: istio-system
 spec:
   ports:
-  - port: 15010
-    name: grpc-xds
-  - port: 15011
-    name: https-xds
-  - port: 8080
-    name: http-legacy-discovery
-  - port: 15014
-    name: http-monitoring
+  - name: grpc-xds
+    port: 15010
+  - name: https-xds
+    port: 15011
+  - name: http-legacy-discovery
+    port: 8080
+  - name: http-monitoring
+    port: 15014
   selector:
     istio: pilot
 ---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-pilot-service-account
-  namespace: istio-system
   labels:
     app: pilot
     release: istio
+  name: istio-pilot-service-account
+  namespace: istio-system
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -7709,10 +7760,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-policy
   labels:
-    release: istio
     app: istio-policy
+    release: istio
+  name: istio-policy
 rules:
 - apiGroups:
   - config.istio.io
@@ -7759,10 +7810,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-policy-admin-role-binding-istio-system
   labels:
     app: istio-policy
     release: istio
+  name: istio-policy-admin-role-binding-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -7775,14 +7826,18 @@ subjects:
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: istio-policy
-  namespace: istio-system
   labels:
     app: istio-policy
     release: istio
+  name: istio-policy
+  namespace: istio-system
 spec:
   host: istio-policy.istio-system.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      http:
+        http2MaxRequests: 10000
+        maxRequestsPerConnection: 10000
     portLevelSettings:
     - port:
         number: 15004
@@ -7792,18 +7847,8 @@ spec:
         number: 9091
       tls:
         mode: DISABLE
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: policy-envoy-config
-  labels:
-    release: istio
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -8126,10 +8171,28 @@ data:
                             route:
                               cluster: out.galley.15019
                               timeout: 0.000s
+kind: ConfigMap
+metadata:
+  labels:
+    release: istio
+  name: policy-envoy-config
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/mixer:1.4.5
+        URL: index.docker.io/istio/mixer@sha256:ff6f39732c31999911790b00b484a471b6fe87192223d3266b0b6e752a374287
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/proxyv2:1.4.5
+        URL: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
   labels:
     app: istio-policy
     istio: mixer
@@ -8204,7 +8267,7 @@ spec:
             fieldRef:
               apiVersion: v1
               fieldPath: metadata.namespace
-        image: docker.io/istio/mixer:1.4.5
+        image: index.docker.io/istio/mixer@sha256:ff6f39732c31999911790b00b484a471b6fe87192223d3266b0b6e752a374287
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -8258,7 +8321,7 @@ spec:
               fieldPath: status.podIP
         - name: SDS_ENABLED
           value: "false"
-        image: docker.io/istio/proxyv2:1.4.5
+        image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -8300,15 +8363,15 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-policy
-  namespace: istio-system
-  labels:
-    app: policy
-    release: istio
-    istio: mixer
-    istio-mixer-type: policy
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: policy
+    istio: mixer
+    istio-mixer-type: policy
+    release: istio
+  name: istio-policy
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -8320,12 +8383,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-policy
-  namespace: istio-system
   labels:
     app: mixer
     istio: mixer
     release: istio
+  name: istio-policy
+  namespace: istio-system
 spec:
   ports:
   - name: grpc-mixer
@@ -8341,11 +8404,11 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-policy-service-account
-  namespace: istio-system
   labels:
     app: istio-policy
     release: istio
+  name: istio-policy-service-account
+  namespace: istio-system
 ---
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
@@ -8371,10 +8434,10 @@ spec:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: istio-mixer-istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: istio-mixer-istio-system
 rules:
 - apiGroups:
   - config.istio.io
@@ -8421,10 +8484,10 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: istio-mixer-admin-role-binding-istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: istio-mixer-admin-role-binding-istio-system
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
@@ -8437,30 +8500,100 @@ subjects:
 apiVersion: config.istio.io/v1alpha2
 kind: attributemanifest
 metadata:
-  name: istioproxy
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: istioproxy
+  namespace: istio-system
 spec:
   attributes:
+    api.operation:
+      valueType: STRING
+    api.protocol:
+      valueType: STRING
+    api.service:
+      valueType: STRING
+    api.version:
+      valueType: STRING
+    check.cache_hit:
+      valueType: BOOL
+    check.error_code:
+      valueType: INT64
+    check.error_message:
+      valueType: STRING
+    connection.duration:
+      valueType: DURATION
+    connection.event:
+      valueType: STRING
+    connection.id:
+      valueType: STRING
+    connection.mtls:
+      valueType: BOOL
+    connection.received.bytes:
+      valueType: INT64
+    connection.received.bytes_total:
+      valueType: INT64
+    connection.requested_server_name:
+      valueType: STRING
+    connection.sent.bytes:
+      valueType: INT64
+    connection.sent.bytes_total:
+      valueType: INT64
+    context.protocol:
+      valueType: STRING
+    context.proxy_error_code:
+      valueType: STRING
+    context.proxy_version:
+      valueType: STRING
+    context.reporter.kind:
+      valueType: STRING
+    context.reporter.local:
+      valueType: BOOL
+    context.reporter.uid:
+      valueType: STRING
+    context.time:
+      valueType: TIMESTAMP
+    context.timestamp:
+      valueType: TIMESTAMP
+    destination.port:
+      valueType: INT64
+    destination.principal:
+      valueType: STRING
+    destination.uid:
+      valueType: STRING
     origin.ip:
       valueType: IP_ADDRESS
     origin.uid:
       valueType: STRING
     origin.user:
       valueType: STRING
+    quota.cache_hit:
+      valueType: BOOL
+    rbac.permissive.effective_policy_id:
+      valueType: STRING
+    rbac.permissive.response_code:
+      valueType: STRING
+    request.api_key:
+      valueType: STRING
+    request.auth.audiences:
+      valueType: STRING
+    request.auth.claims:
+      valueType: STRING_MAP
+    request.auth.presenter:
+      valueType: STRING
+    request.auth.principal:
+      valueType: STRING
+    request.auth.raw_claims:
+      valueType: STRING
     request.headers:
       valueType: STRING_MAP
-    request.id:
-      valueType: STRING
     request.host:
+      valueType: STRING
+    request.id:
       valueType: STRING
     request.method:
       valueType: STRING
     request.path:
-      valueType: STRING
-    request.url_path:
       valueType: STRING
     request.query_params:
       valueType: STRING_MAP
@@ -8470,119 +8603,79 @@ spec:
       valueType: STRING
     request.scheme:
       valueType: STRING
-    request.total_size:
-      valueType: INT64
     request.size:
       valueType: INT64
     request.time:
       valueType: TIMESTAMP
+    request.total_size:
+      valueType: INT64
+    request.url_path:
+      valueType: STRING
     request.useragent:
       valueType: STRING
     response.code:
       valueType: INT64
     response.duration:
       valueType: DURATION
+    response.grpc_message:
+      valueType: STRING
+    response.grpc_status:
+      valueType: STRING
     response.headers:
       valueType: STRING_MAP
-    response.total_size:
-      valueType: INT64
     response.size:
       valueType: INT64
     response.time:
       valueType: TIMESTAMP
-    response.grpc_status:
-      valueType: STRING
-    response.grpc_message:
+    response.total_size:
+      valueType: INT64
+    source.principal:
       valueType: STRING
     source.uid:
       valueType: STRING
     source.user:
       valueType: STRING
-    source.principal:
-      valueType: STRING
-    destination.uid:
-      valueType: STRING
-    destination.principal:
-      valueType: STRING
-    destination.port:
-      valueType: INT64
-    connection.event:
-      valueType: STRING
-    connection.id:
-      valueType: STRING
-    connection.received.bytes:
-      valueType: INT64
-    connection.received.bytes_total:
-      valueType: INT64
-    connection.sent.bytes:
-      valueType: INT64
-    connection.sent.bytes_total:
-      valueType: INT64
-    connection.duration:
-      valueType: DURATION
-    connection.mtls:
-      valueType: BOOL
-    connection.requested_server_name:
-      valueType: STRING
-    context.protocol:
-      valueType: STRING
-    context.proxy_error_code:
-      valueType: STRING
-    context.timestamp:
-      valueType: TIMESTAMP
-    context.time:
-      valueType: TIMESTAMP
-    context.reporter.local:
-      valueType: BOOL
-    context.reporter.kind:
-      valueType: STRING
-    context.reporter.uid:
-      valueType: STRING
-    context.proxy_version:
-      valueType: STRING
-    api.service:
-      valueType: STRING
-    api.version:
-      valueType: STRING
-    api.operation:
-      valueType: STRING
-    api.protocol:
-      valueType: STRING
-    request.auth.principal:
-      valueType: STRING
-    request.auth.audiences:
-      valueType: STRING
-    request.auth.presenter:
-      valueType: STRING
-    request.auth.claims:
-      valueType: STRING_MAP
-    request.auth.raw_claims:
-      valueType: STRING
-    request.api_key:
-      valueType: STRING
-    rbac.permissive.response_code:
-      valueType: STRING
-    rbac.permissive.effective_policy_id:
-      valueType: STRING
-    check.error_code:
-      valueType: INT64
-    check.error_message:
-      valueType: STRING
-    check.cache_hit:
-      valueType: BOOL
-    quota.cache_hit:
-      valueType: BOOL
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: attributemanifest
 metadata:
-  name: kubernetes
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: kubernetes
+  namespace: istio-system
 spec:
   attributes:
+    destination.container.name:
+      valueType: STRING
+    destination.ip:
+      valueType: IP_ADDRESS
+    destination.labels:
+      valueType: STRING_MAP
+    destination.metadata:
+      valueType: STRING_MAP
+    destination.name:
+      valueType: STRING
+    destination.namespace:
+      valueType: STRING
+    destination.owner:
+      valueType: STRING
+    destination.service.host:
+      valueType: STRING
+    destination.service.name:
+      valueType: STRING
+    destination.service.namespace:
+      valueType: STRING
+    destination.service.uid:
+      valueType: STRING
+    destination.serviceAccount:
+      valueType: STRING
+    destination.workload.name:
+      valueType: STRING
+    destination.workload.namespace:
+      valueType: STRING
+    destination.workload.uid:
+      valueType: STRING
     source.ip:
       valueType: IP_ADDRESS
     source.labels:
@@ -8599,351 +8692,318 @@ spec:
       valueType: STRING
     source.services:
       valueType: STRING
-    source.workload.uid:
-      valueType: STRING
     source.workload.name:
       valueType: STRING
     source.workload.namespace:
       valueType: STRING
-    destination.ip:
-      valueType: IP_ADDRESS
-    destination.labels:
-      valueType: STRING_MAP
-    destination.metadata:
-      valueType: STRING_MAP
-    destination.owner:
-      valueType: STRING
-    destination.name:
-      valueType: STRING
-    destination.container.name:
-      valueType: STRING
-    destination.namespace:
-      valueType: STRING
-    destination.service.uid:
-      valueType: STRING
-    destination.service.name:
-      valueType: STRING
-    destination.service.namespace:
-      valueType: STRING
-    destination.service.host:
-      valueType: STRING
-    destination.serviceAccount:
-      valueType: STRING
-    destination.workload.uid:
-      valueType: STRING
-    destination.workload.name:
-      valueType: STRING
-    destination.workload.namespace:
+    source.workload.uid:
       valueType: STRING
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: requestcount
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: "1"
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound")
+        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
+        "none"))
       destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
+      destination_principal: destination.principal | "unknown"
       destination_service: destination.service.host | conditional((destination.service.name
         | "unknown") == "unknown", "unknown", request.host)
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       request_protocol: api.protocol | context.protocol | "unknown"
       response_code: response.code | 200
       response_flags: context.proxy_error_code | "-"
-      permissive_response_code: rbac.permissive.response_code | "none"
-      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-      connection_security_policy: conditional((context.reporter.kind | "inbound")
-        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
-        "none"))
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: "1"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: requestduration
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: response.duration | "0ms"
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound")
+        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
+        "none"))
       destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
+      destination_principal: destination.principal | "unknown"
       destination_service: destination.service.host | conditional((destination.service.name
         | "unknown") == "unknown", "unknown", request.host)
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       request_protocol: api.protocol | context.protocol | "unknown"
       response_code: response.code | 200
       response_flags: context.proxy_error_code | "-"
-      permissive_response_code: rbac.permissive.response_code | "none"
-      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-      connection_security_policy: conditional((context.reporter.kind | "inbound")
-        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
-        "none"))
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: response.duration | "0ms"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: requestsize
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: request.size | 0
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound")
+        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
+        "none"))
       destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
+      destination_principal: destination.principal | "unknown"
       destination_service: destination.service.host | conditional((destination.service.name
         | "unknown") == "unknown", "unknown", request.host)
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       request_protocol: api.protocol | context.protocol | "unknown"
       response_code: response.code | 200
       response_flags: context.proxy_error_code | "-"
-      permissive_response_code: rbac.permissive.response_code | "none"
-      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-      connection_security_policy: conditional((context.reporter.kind | "inbound")
-        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
-        "none"))
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: request.size | 0
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: responsesize
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: response.size | 0
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
+      connection_security_policy: conditional((context.reporter.kind | "inbound")
+        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
+        "none"))
       destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
+      destination_principal: destination.principal | "unknown"
       destination_service: destination.service.host | conditional((destination.service.name
         | "unknown") == "unknown", "unknown", request.host)
       destination_service_name: destination.service.name | "unknown"
       destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      permissive_response_code: rbac.permissive.response_code | "none"
+      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       request_protocol: api.protocol | context.protocol | "unknown"
       response_code: response.code | 200
       response_flags: context.proxy_error_code | "-"
-      permissive_response_code: rbac.permissive.response_code | "none"
-      permissive_response_policyid: rbac.permissive.effective_policy_id | "none"
-      connection_security_policy: conditional((context.reporter.kind | "inbound")
-        == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
-        "none"))
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: response.size | 0
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: tcpbytesent
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: connection.sent.bytes | 0
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
       connection_security_policy: conditional((context.reporter.kind | "inbound")
         == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
         "none"))
+      destination_app: destination.labels["app"] | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       response_flags: context.proxy_error_code | "-"
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: connection.sent.bytes | 0
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: tcpbytereceived
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: connection.received.bytes | 0
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
       connection_security_policy: conditional((context.reporter.kind | "inbound")
         == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
         "none"))
+      destination_app: destination.labels["app"] | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       response_flags: context.proxy_error_code | "-"
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: connection.received.bytes | 0
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
+  labels:
+    app: istio-telemetry
+    release: istio
   name: tcpconnectionsopened
   namespace: istio-system
-  labels:
-    app: istio-telemetry
-    release: istio
 spec:
   compiledTemplate: metric
   params:
-    value: "1"
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
       connection_security_policy: conditional((context.reporter.kind | "inbound")
         == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
         "none"))
+      destination_app: destination.labels["app"] | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       response_flags: context.proxy_error_code | "-"
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: "1"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
-  name: tcpconnectionsclosed
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: tcpconnectionsclosed
+  namespace: istio-system
 spec:
   compiledTemplate: metric
   params:
-    value: "1"
     dimensions:
-      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
-        "destination")
-      source_workload: source.workload.name | "unknown"
-      source_workload_namespace: source.workload.namespace | "unknown"
-      source_principal: source.principal | "unknown"
-      source_app: source.labels["app"] | "unknown"
-      source_version: source.labels["version"] | "unknown"
-      destination_workload: destination.workload.name | "unknown"
-      destination_workload_namespace: destination.workload.namespace | "unknown"
-      destination_principal: destination.principal | "unknown"
-      destination_app: destination.labels["app"] | "unknown"
-      destination_version: destination.labels["version"] | "unknown"
-      destination_service: destination.service.host | "unknown"
-      destination_service_name: destination.service.name | "unknown"
-      destination_service_namespace: destination.service.namespace | "unknown"
       connection_security_policy: conditional((context.reporter.kind | "inbound")
         == "outbound", "unknown", conditional(connection.mtls | false, "mutual_tls",
         "none"))
+      destination_app: destination.labels["app"] | "unknown"
+      destination_principal: destination.principal | "unknown"
+      destination_service: destination.service.host | "unknown"
+      destination_service_name: destination.service.name | "unknown"
+      destination_service_namespace: destination.service.namespace | "unknown"
+      destination_version: destination.labels["version"] | "unknown"
+      destination_workload: destination.workload.name | "unknown"
+      destination_workload_namespace: destination.workload.namespace | "unknown"
+      reporter: conditional((context.reporter.kind | "inbound") == "outbound", "source",
+        "destination")
       response_flags: context.proxy_error_code | "-"
+      source_app: source.labels["app"] | "unknown"
+      source_principal: source.principal | "unknown"
+      source_version: source.labels["version"] | "unknown"
+      source_workload: source.workload.name | "unknown"
+      source_workload_namespace: source.workload.namespace | "unknown"
     monitored_resource_type: '"UNSPECIFIED"'
+    value: "1"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: handler
 metadata:
-  name: prometheus
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: prometheus
+  namespace: istio-system
 spec:
   compiledAdapter: prometheus
   params:
-    metricsExpirationPolicy:
-      metricsExpiryDuration: 10m
     metrics:
-    - name: requests_total
-      instance_name: requestcount.instance.istio-system
+    - instance_name: requestcount.instance.istio-system
       kind: COUNTER
       label_names:
       - reporter
@@ -8966,7 +9026,21 @@ spec:
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
-    - name: request_duration_seconds
+      name: requests_total
+    - buckets:
+        explicit_buckets:
+          bounds:
+          - 0.005
+          - 0.01
+          - 0.025
+          - 0.05
+          - 0.1
+          - 0.25
+          - 0.5
+          - 1
+          - 2.5
+          - 5
+          - 10
       instance_name: requestduration.instance.istio-system
       kind: DISTRIBUTION
       label_names:
@@ -8990,21 +9064,12 @@ spec:
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
-      buckets:
-        explicit_buckets:
-          bounds:
-          - 0.005
-          - 0.01
-          - 0.025
-          - 0.05
-          - 0.1
-          - 0.25
-          - 0.5
-          - 1
-          - 2.5
-          - 5
-          - 10
-    - name: request_bytes
+      name: request_duration_seconds
+    - buckets:
+        exponentialBuckets:
+          growthFactor: 10
+          numFiniteBuckets: 8
+          scale: 1
       instance_name: requestsize.instance.istio-system
       kind: DISTRIBUTION
       label_names:
@@ -9028,12 +9093,12 @@ spec:
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
-      buckets:
+      name: request_bytes
+    - buckets:
         exponentialBuckets:
+          growthFactor: 10
           numFiniteBuckets: 8
           scale: 1
-          growthFactor: 10
-    - name: response_bytes
       instance_name: responsesize.instance.istio-system
       kind: DISTRIBUTION
       label_names:
@@ -9057,13 +9122,8 @@ spec:
       - permissive_response_code
       - permissive_response_policyid
       - connection_security_policy
-      buckets:
-        exponentialBuckets:
-          numFiniteBuckets: 8
-          scale: 1
-          growthFactor: 10
-    - name: tcp_sent_bytes_total
-      instance_name: tcpbytesent.instance.istio-system
+      name: response_bytes
+    - instance_name: tcpbytesent.instance.istio-system
       kind: COUNTER
       label_names:
       - reporter
@@ -9082,8 +9142,8 @@ spec:
       - destination_service_namespace
       - connection_security_policy
       - response_flags
-    - name: tcp_received_bytes_total
-      instance_name: tcpbytereceived.instance.istio-system
+      name: tcp_sent_bytes_total
+    - instance_name: tcpbytereceived.instance.istio-system
       kind: COUNTER
       label_names:
       - reporter
@@ -9102,8 +9162,8 @@ spec:
       - destination_service_namespace
       - connection_security_policy
       - response_flags
-    - name: tcp_connections_opened_total
-      instance_name: tcpconnectionsopened.instance.istio-system
+      name: tcp_received_bytes_total
+    - instance_name: tcpconnectionsopened.instance.istio-system
       kind: COUNTER
       label_names:
       - reporter
@@ -9122,8 +9182,8 @@ spec:
       - destination_service_namespace
       - connection_security_policy
       - response_flags
-    - name: tcp_connections_closed_total
-      instance_name: tcpconnectionsclosed.instance.istio-system
+      name: tcp_connections_opened_total
+    - instance_name: tcpconnectionsclosed.instance.istio-system
       kind: COUNTER
       label_names:
       - reporter
@@ -9142,19 +9202,19 @@ spec:
       - destination_service_namespace
       - connection_security_policy
       - response_flags
+      name: tcp_connections_closed_total
+    metricsExpirationPolicy:
+      metricsExpiryDuration: 10m
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: promhttp
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: promhttp
+  namespace: istio-system
 spec:
-  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent
-    | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*")
-    == false)
   actions:
   - handler: prometheus
     instances:
@@ -9162,61 +9222,64 @@ spec:
     - requestduration
     - requestsize
     - responsesize
+  match: (context.protocol == "http" || context.protocol == "grpc") && (match((request.useragent
+    | "-"), "kube-probe*") == false) && (match((request.useragent | "-"), "Prometheus*")
+    == false)
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: promtcp
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: promtcp
+  namespace: istio-system
 spec:
-  match: context.protocol == "tcp"
   actions:
   - handler: prometheus
     instances:
     - tcpbytesent
     - tcpbytereceived
+  match: context.protocol == "tcp"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: promtcpconnectionopen
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: promtcpconnectionopen
+  namespace: istio-system
 spec:
-  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
   actions:
   - handler: prometheus
     instances:
     - tcpconnectionsopened
+  match: context.protocol == "tcp" && ((connection.event | "na") == "open")
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: promtcpconnectionclosed
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: promtcpconnectionclosed
+  namespace: istio-system
 spec:
-  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
   actions:
   - handler: prometheus
     instances:
     - tcpconnectionsclosed
+  match: context.protocol == "tcp" && ((connection.event | "na") == "close")
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: handler
 metadata:
-  name: kubernetesenv
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: kubernetesenv
+  namespace: istio-system
 spec:
   compiledAdapter: kubernetesenv
   params: null
@@ -9224,11 +9287,11 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: kubeattrgenrulerule
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: kubeattrgenrulerule
+  namespace: istio-system
 spec:
   actions:
   - handler: kubernetesenv
@@ -9238,67 +9301,71 @@ spec:
 apiVersion: config.istio.io/v1alpha2
 kind: rule
 metadata:
-  name: tcpkubeattrgenrulerule
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: tcpkubeattrgenrulerule
+  namespace: istio-system
 spec:
-  match: context.protocol == "tcp"
   actions:
   - handler: kubernetesenv
     instances:
     - attributes
+  match: context.protocol == "tcp"
 ---
 apiVersion: config.istio.io/v1alpha2
 kind: instance
 metadata:
-  name: attributes
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: attributes
+  namespace: istio-system
 spec:
-  compiledTemplate: kubernetes
-  params:
-    source_uid: source.uid | ""
-    source_ip: source.ip | ip("0.0.0.0")
-    destination_uid: destination.uid | ""
-    destination_port: destination.port | 0
   attributeBindings:
+    destination.container.name: $out.destination_container_name | "unknown"
+    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
+    destination.labels: $out.destination_labels | emptyStringMap()
+    destination.name: $out.destination_pod_name | "unknown"
+    destination.namespace: $out.destination_namespace | "default"
+    destination.owner: $out.destination_owner | "unknown"
+    destination.serviceAccount: $out.destination_service_account_name | "unknown"
+    destination.uid: $out.destination_pod_uid | "unknown"
+    destination.workload.name: $out.destination_workload_name | "unknown"
+    destination.workload.namespace: $out.destination_workload_namespace | "unknown"
+    destination.workload.uid: $out.destination_workload_uid | "unknown"
     source.ip: $out.source_pod_ip | ip("0.0.0.0")
-    source.uid: $out.source_pod_uid | "unknown"
     source.labels: $out.source_labels | emptyStringMap()
     source.name: $out.source_pod_name | "unknown"
     source.namespace: $out.source_namespace | "default"
     source.owner: $out.source_owner | "unknown"
     source.serviceAccount: $out.source_service_account_name | "unknown"
-    source.workload.uid: $out.source_workload_uid | "unknown"
+    source.uid: $out.source_pod_uid | "unknown"
     source.workload.name: $out.source_workload_name | "unknown"
     source.workload.namespace: $out.source_workload_namespace | "unknown"
-    destination.ip: $out.destination_pod_ip | ip("0.0.0.0")
-    destination.uid: $out.destination_pod_uid | "unknown"
-    destination.labels: $out.destination_labels | emptyStringMap()
-    destination.name: $out.destination_pod_name | "unknown"
-    destination.container.name: $out.destination_container_name | "unknown"
-    destination.namespace: $out.destination_namespace | "default"
-    destination.owner: $out.destination_owner | "unknown"
-    destination.serviceAccount: $out.destination_service_account_name | "unknown"
-    destination.workload.uid: $out.destination_workload_uid | "unknown"
-    destination.workload.name: $out.destination_workload_name | "unknown"
-    destination.workload.namespace: $out.destination_workload_namespace | "unknown"
+    source.workload.uid: $out.source_workload_uid | "unknown"
+  compiledTemplate: kubernetes
+  params:
+    destination_port: destination.port | 0
+    destination_uid: destination.uid | ""
+    source_ip: source.ip | ip("0.0.0.0")
+    source_uid: source.uid | ""
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: DestinationRule
 metadata:
-  name: istio-telemetry
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: istio-telemetry
+  namespace: istio-system
 spec:
   host: istio-telemetry.istio-system.svc.cluster.local
   trafficPolicy:
+    connectionPool:
+      http:
+        http2MaxRequests: 10000
+        maxRequestsPerConnection: 10000
     portLevelSettings:
     - port:
         number: 15004
@@ -9308,18 +9375,8 @@ spec:
         number: 9091
       tls:
         mode: DISABLE
-    connectionPool:
-      http:
-        http2MaxRequests: 10000
-        maxRequestsPerConnection: 10000
 ---
 apiVersion: v1
-kind: ConfigMap
-metadata:
-  namespace: istio-system
-  name: telemetry-envoy-config
-  labels:
-    release: istio
 data:
   envoy.yaml.tmpl: |-
     admin:
@@ -9605,10 +9662,28 @@ data:
                             route:
                               cluster: out.galley.15019
                               timeout: 0.000s
+kind: ConfigMap
+metadata:
+  labels:
+    release: istio
+  name: telemetry-envoy-config
+  namespace: istio-system
 ---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    kbld.k14s.io/images: |
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/mixer:1.4.5
+        URL: index.docker.io/istio/mixer@sha256:ff6f39732c31999911790b00b484a471b6fe87192223d3266b0b6e752a374287
+      - Metas:
+        - Tag: 1.4.5
+          Type: resolved
+          URL: docker.io/istio/proxyv2:1.4.5
+        URL: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
   labels:
     app: istio-mixer
     istio: mixer
@@ -9686,7 +9761,7 @@ spec:
               fieldPath: metadata.namespace
         - name: GOMAXPROCS
           value: "6"
-        image: docker.io/istio/mixer:1.4.5
+        image: index.docker.io/istio/mixer@sha256:ff6f39732c31999911790b00b484a471b6fe87192223d3266b0b6e752a374287
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:
@@ -9744,7 +9819,7 @@ spec:
               fieldPath: status.podIP
         - name: SDS_ENABLED
           value: "false"
-        image: docker.io/istio/proxyv2:1.4.5
+        image: index.docker.io/istio/proxyv2@sha256:fc09ea0f969147a4843a564c5b677fbf3a6f94b56627d00b313b4c30d5fef094
         imagePullPolicy: IfNotPresent
         name: istio-proxy
         ports:
@@ -9786,15 +9861,15 @@ spec:
 apiVersion: policy/v1beta1
 kind: PodDisruptionBudget
 metadata:
-  name: istio-telemetry
-  namespace: istio-system
-  labels:
-    app: telemetry
-    release: istio
-    istio: mixer
-    istio-mixer-type: telemetry
   annotations:
     kapp.k14s.io/update-strategy: fallback-on-replace
+  labels:
+    app: telemetry
+    istio: mixer
+    istio-mixer-type: telemetry
+    release: istio
+  name: istio-telemetry
+  namespace: istio-system
 spec:
   minAvailable: 1
   selector:
@@ -9806,12 +9881,12 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: istio-telemetry
-  namespace: istio-system
   labels:
     app: mixer
     istio: mixer
     release: istio
+  name: istio-telemetry
+  namespace: istio-system
 spec:
   ports:
   - name: grpc-mixer
@@ -9829,11 +9904,11 @@ spec:
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: istio-mixer-service-account
-  namespace: istio-system
   labels:
     app: istio-telemetry
     release: istio
+  name: istio-mixer-service-account
+  namespace: istio-system
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -9841,16 +9916,16 @@ metadata:
   name: pilot-network-policy
   namespace: istio-system
 spec:
-  podSelector:
-    matchLabels:
-      app: pilot
-  policyTypes:
-  - Ingress
   ingress:
   - ports:
     - port: 15004
     - port: 15010
     - port: 15011
+  podSelector:
+    matchLabels:
+      app: pilot
+  policyTypes:
+  - Ingress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -9858,11 +9933,6 @@ metadata:
   name: citadel-network-policy
   namespace: istio-system
 spec:
-  podSelector:
-    matchLabels:
-      app: citadel
-  policyTypes:
-  - Ingress
   ingress:
   - from:
     - namespaceSelector:
@@ -9873,6 +9943,11 @@ spec:
     - port: 8080
   - ports:
     - port: 15014
+  podSelector:
+    matchLabels:
+      app: citadel
+  policyTypes:
+  - Ingress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -9880,11 +9955,6 @@ metadata:
   name: mixer-network-policy
   namespace: istio-system
 spec:
-  podSelector:
-    matchLabels:
-      app: mixer
-  policyTypes:
-  - Ingress
   ingress:
   - from:
     - namespaceSelector:
@@ -9897,6 +9967,11 @@ spec:
     - port: 42422
   - ports:
     - port: 15014
+  podSelector:
+    matchLabels:
+      app: mixer
+  policyTypes:
+  - Ingress
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -9904,15 +9979,15 @@ metadata:
   name: sidecar-injector-network-policy
   namespace: istio-system
 spec:
+  ingress:
+  - ports:
+    - port: 9443
+    - port: 15014
   podSelector:
     matchLabels:
       app: sidecarInjectorWebhook
   policyTypes:
   - Ingress
-  ingress:
-  - ports:
-    - port: 9443
-    - port: 15014
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -9920,11 +9995,6 @@ metadata:
   name: ingressgateway-network-policy-pilot
   namespace: istio-system
 spec:
-  podSelector:
-    matchLabels:
-      app: istio-ingressgateway
-  policyTypes:
-  - Ingress
   ingress:
   - from:
     - namespaceSelector:
@@ -9936,6 +10006,11 @@ spec:
   - ports:
     - port: 80
     - port: 443
+  podSelector:
+    matchLabels:
+      app: istio-ingressgateway
+  policyTypes:
+  - Ingress
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: Sidecar

--- a/config/istio/build.sh
+++ b/config/istio/build.sh
@@ -3,4 +3,4 @@ set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 
-${SCRIPT_DIR}/generate.sh "$@"  > "${SCRIPT_DIR}/../istio-generated/xxx-generated-istio.yaml"
+${SCRIPT_DIR}/generate.sh "$@" | kbld -f - > "${SCRIPT_DIR}/../istio-generated/xxx-generated-istio.yaml"


### PR DESCRIPTION
As part of RelInt's work to resolve all image references with digests instead of tags, this PR uses [kbld](https://get-kbld.io) (one of the [k14s](https://k14s.io)) to resolve/rewrite the Istio image references in the `xxx-generated-istio.yaml`.

One unfortunate side-effect of using `kbld` is that all keys in that file are re-sorted alphabetically, but we feel that this is acceptable as this is an automatically generated file, and this is a one-time thing as it will already be sorted going forward.

Regards,
Dave and @acosta11