### PR TITLE
Add additional printer columns to Route CRD

### DIFF
--- a/config/crd/networking.cloudfoundry.org_routes.yaml
+++ b/config/crd/networking.cloudfoundry.org_routes.yaml
@@ -17,6 +17,13 @@ spec:
   scope: Namespaced
   subresources:
     status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .spec.url
+  - name: Age
+    type: date
+    JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
       description: Route is the Schema for the routes API

--- a/routecontroller/apis/networking/v1alpha1/route_types.go
+++ b/routecontroller/apis/networking/v1alpha1/route_types.go
@@ -76,6 +76,8 @@ type Condition struct {
 // +kubebuilder:subresource:status
 
 // Route is the Schema for the routes API
+// +kubebuilder:printcolumn:name="URL",type=string,JSONPath=`.spec.url`
+// +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 type Route struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/routecontroller/config/crd/bases/networking.cloudfoundry.org_routes.yaml
+++ b/routecontroller/config/crd/bases/networking.cloudfoundry.org_routes.yaml
@@ -8,6 +8,13 @@ metadata:
   creationTimestamp: null
   name: routes.networking.cloudfoundry.org
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.url
+    name: URL
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    name: Age
+    type: date
   group: networking.cloudfoundry.org
   names:
     kind: Route

--- a/routecontroller/resourcebuilders/service_builder_test.go
+++ b/routecontroller/resourcebuilders/service_builder_test.go
@@ -139,17 +139,17 @@ var _ = Describe("ServiceBuilder", func() {
 		Context("when a route has no destinations", func() {
 			It("does not create a Service", func() {
 				route := networkingv1alpha1.RouteList{
-							Items: []networkingv1alpha1.Route{
-								constructRoute(routeParams{
-									name:         "route-guid-1",
-									host:         "test0",
-									path:         "/path0/deeper",
-									domain:       "domain0.example.com",
-									internal:     true,
-									destinations: []routeDestParams{},
-								}),
-							},
-						}
+					Items: []networkingv1alpha1.Route{
+						constructRoute(routeParams{
+							name:         "route-guid-1",
+							host:         "test0",
+							path:         "/path0/deeper",
+							domain:       "domain0.example.com",
+							internal:     true,
+							destinations: []routeDestParams{},
+						}),
+					},
+				}
 
 				builder := ServiceBuilder{}
 				Expect(builder.Build(&route.Items[0])).To(BeEmpty())


### PR DESCRIPTION
### Summary of changes
Add additional printer columns to Route CRD so the App GUIDs and Route URL is displayed when `kubectl get routes -owide` is performed.

### Related Issue(s)
Fixes #48 

### Additional Context
-_Include any links to related PRs, stories, slack discussions, etc... that will help establish context._
-_Is there anything else of note that the reviewers should know about this change?_

### Acceptance Steps

1. Map an app to a route
2. Run `kubectl get routes -n cf-workloads -owide`
3. Verify that Route name, URL, and age is displayed and match to the route.


