### PR TITLE
Add project to GKE version function

### DIFF
--- a/hack/cf4k8s/methods.sh
+++ b/hack/cf4k8s/methods.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 function latest_cluster_version() {
-  gcloud container get-server-config --zone us-west1-a 2>/dev/null | yq .validMasterVersions[0] -r
+  gcloud container get-server-config --zone us-west1-a --project ${GCP_PROJECT} 2>/dev/null | yq .validMasterVersions[0] -r
 }
 
 function credhub_get_gcp_service_account_key() {


### PR DESCRIPTION
If you don't have a default project set to `gcloud` it will pick up the oldest version.