### PR TITLE
add labels to routecontroller resources

### DIFF
--- a/config/routecontroller/cluster-role-binding.yaml
+++ b/config/routecontroller/cluster-role-binding.yaml
@@ -6,6 +6,10 @@ kind: ClusterRoleBinding
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/routecontroller/cluster-role.yaml
+++ b/config/routecontroller/cluster-role.yaml
@@ -6,6 +6,10 @@ kind: ClusterRole
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 rules:
 - apiGroups: ["networking.cloudfoundry.org"]
   resources: ["routes", "routes/status"]

--- a/config/routecontroller/routecontroller-configmap.yaml
+++ b/config/routecontroller/routecontroller-configmap.yaml
@@ -8,6 +8,10 @@ metadata:
   annotations:
     kapp.k14s.io/versioned: ""
     kapp.k14s.io/num-versions: "2"
+  labels:
+    app.kubernetes.io/name: routecontroller-config
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 data:
   ISTIO_GATEWAY_NAME: cf-system/istio-ingressgateway
   RESYNC_INTERVAL: "900"

--- a/config/routecontroller/routecontroller.yaml
+++ b/config/routecontroller/routecontroller.yaml
@@ -8,6 +8,9 @@ metadata:
   namespace: #@ data.values.systemNamespace
   labels:
     app: routecontroller
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry
 spec:
   replicas: 1
   selector:
@@ -18,6 +21,9 @@ spec:
       namespace: #@ data.values.systemNamespace
       labels:
         app: routecontroller
+        app.kubernetes.io/name: routecontroller
+        app.kubernetes.io/component: cf-networking
+        app.kubernetes.io/part-of: cloudfoundry
     spec:
       containers:
       - name: routecontroller

--- a/config/routecontroller/service-account.yaml
+++ b/config/routecontroller/service-account.yaml
@@ -6,3 +6,7 @@ kind: ServiceAccount
 metadata:
   name: routecontroller
   namespace: #@ data.values.systemNamespace
+  labels:
+    app.kubernetes.io/name: routecontroller
+    app.kubernetes.io/component: cf-networking
+    app.kubernetes.io/part-of: cloudfoundry


### PR DESCRIPTION
Adds a few of the "Recommended Labels"[0] to the resources related to
RouteController which will align us closer with the CF "Kubernetes Guidelines"[1]. It will make our components more consistent with the rest of the CF system components.

The label values are similar to what was discussed in the [Route CRD proposal](https://docs.google.com/document/d/1DF7eTBut1I74w_sVaQ4eeF74iQes1nG3iUv7iJ7E35U/edit#heading=h.e1g4y03lzaln).

Additionally I [created a story](https://www.pivotaltracker.com/story/show/173631033) to add the `app.kubernetes.io/version` label as part of our release process.

[0] https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
[1] https://github.com/cloudfoundry-incubator/kubernetes-guidelines