### PR TITLE
Make ingressgateway access logs visible via `cf logs` [DaemonSet version]

### DIFF
--- a/config/istio-config/ingressgateway-fluent-bit-forwarder-config.yaml
+++ b/config/istio-config/ingressgateway-fluent-bit-forwarder-config.yaml
@@ -1,0 +1,59 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingressgateway-fluent-bit-forwarder-config
+  namespace: cf-system
+data:
+  fluent-bit.conf: |-
+    [SERVICE]
+        Flush          1
+        Daemon         Off
+        Log_Level      info
+        Parsers_File   parsers.conf
+
+    [INPUT]
+        Name    tail
+        Tag     istio-ingressgateway
+        Path    /var/log/containers/istio-ingressgateway*istio-proxy*.log
+        Parser  json-test
+        Refresh_Interval 1
+
+    [FILTER]
+        Name parser
+        Match istio-ingressgateway
+        Parser json-test
+        Key_Name log
+
+    [FILTER]
+        Name lua
+        Match istio-ingressgateway
+        script transform_record.lua
+        call transform_record
+
+    [OUTPUT]
+        Name stdout
+        Match istio-ingressgateway
+
+    [OUTPUT]
+        Name forward
+        Match istio-ingressgateway
+        Host fluentd-forwarder-ingress.cf-system
+        Port 24224
+
+  parsers.conf : |-
+    [PARSER]
+        Name   json-test
+        Format json
+        Time_Key time
+
+  transform_record.lua: |-
+    function transform_record(tag, timestamp, record)
+      new_record = {}
+      new_record["app_id"] = record["app_id"]
+      new_record["instance_id"] = 0
+      new_record["log"] = record
+      new_record["source_type"] = "RTR"
+      return 1, timestamp, new_record
+    end
+

--- a/config/istio-config/ingressgateway-fluent-bit-forwarder-daemonset.yaml
+++ b/config/istio-config/ingressgateway-fluent-bit-forwarder-daemonset.yaml
@@ -1,0 +1,45 @@
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ingressgateway-fluent-bit-forwarder
+  namespace: cf-system
+  labels:
+    app: ingressgateway-fluent-bit-forwarder
+spec:
+  selector:
+    matchLabels:
+      app: ingressgateway-fluent-bit-forwarder
+  template:
+    metadata:
+      labels:
+        app: ingressgateway-fluent-bit-forwarder
+    spec:
+      containers:
+      - name: fluent-bit
+        image: fluent/fluent-bit
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc
+        - name: varlog
+          mountPath: /var/log
+        - name: dockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+      terminationGracePeriodSeconds: 10
+      volumes:
+      - name: fluent-bit-config
+        configMap:
+          name: ingressgateway-fluent-bit-forwarder-config
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: dockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/config/istio-config/ingressgateway-fluentd-forwarder-config.yaml
+++ b/config/istio-config/ingressgateway-fluentd-forwarder-config.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: ingressgateway-fluentd-forwarder-config
-  namespace: cf-system
+  namespace: #@ data.values.systemNamespace
 data:
   fluentd.conf: |
     # Inputs

--- a/config/istio-config/ingressgateway-fluentd-forwarder-config.yaml
+++ b/config/istio-config/ingressgateway-fluentd-forwarder-config.yaml
@@ -1,0 +1,56 @@
+#@ load("@ytt:data", "data")
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingressgateway-fluentd-forwarder-config
+  namespace: cf-system
+data:
+  fluentd.conf: |
+    # Inputs
+    <source>
+      @type tail
+      @id in_tail_container_logs
+      path /var/log/containers/istio-ingressgateway*istio-proxy*.log
+      pos_file /var/log/fluentd-istio-ingressgateway.log.pos
+      tag istio-ingressgateway
+      refresh_interval 1
+      <parse>
+        @type json
+        format json
+        time_key time
+        time_format %Y-%m-%dT%H:%M:%S.%NZ
+      </parse>
+      read_from_head true
+    </source>
+
+    # Filters
+    <filter istio-ingressgateway>
+      @type parser
+      format json
+      key_name log
+    </filter>
+
+    <filter istio-ingressgateway>
+      @type record_transformer
+      enable_ruby
+      <record>
+        app_id ${record["app_id"]}
+        instance_id 0
+        log ${record.to_json}
+        source_type RTR
+      </record>
+    </filter>
+
+    <match istio-ingressgateway>
+      @type forward
+      <server>
+        name fluentd_dest
+        host fluentd-forwarder-ingress
+      </server>
+
+      <buffer>
+        @type memory
+        flush_mode immediate
+      </buffer>
+    </match>

--- a/config/istio-config/ingressgateway-fluentd-forwarder-daemonset.yaml
+++ b/config/istio-config/ingressgateway-fluentd-forwarder-daemonset.yaml
@@ -1,0 +1,46 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: ingressgateway-fluentd-forwarder
+  namespace: #@ data.values.systemNamespace
+  labels:
+    app: ingressgateway-fluentd-forwarder
+spec:
+  selector:
+    matchLabels:
+      app: ingressgateway-fluentd-forwarder
+  template:
+    metadata:
+      labels:
+        app: ingressgateway-fluentd-forwarder
+    spec:
+      containers:
+      - name: fluentd
+        image: "logcache/cf-k8s-logging@sha256:71fd09077b70fb43dfe91e4445b6528580355003255c8860f7238aaab7b5370b"
+        resources:
+          limits:
+            memory: 200Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi
+        volumeMounts:
+        - name: fluentd-config
+          mountPath: /fluentd/etc
+        - name: varlog
+          mountPath: /var/log
+        - name: dockercontainers
+          mountPath: /var/lib/docker/containers
+      terminationGracePeriodSeconds: 30
+      volumes:
+      - name: fluentd-config
+        configMap:
+          name: ingressgateway-fluentd-forwarder-config
+      - name: varlog
+        hostPath:
+          path: /var/log
+      - name: dockercontainers
+        hostPath:
+          path: /var/lib/docker/containers

--- a/test/acceptance/acceptance_test.go
+++ b/test/acceptance/acceptance_test.go
@@ -58,8 +58,9 @@ func TestAcceptance(t *testing.T) {
 
 		g := &Globals{}
 		g.SysComponentSelector = createSystemComponent()
-		g.AppGuid = pushApp(generator.PrefixedRandomName("ACCEPTANCE", "app"))
+		g.AppName = generator.PrefixedRandomName("ACCEPTANCE", "app")
 		g.AppsDomain = config.AppsDomain
+		g.AppGuid = pushApp(g.AppName)
 
 		data, err := g.Serialize()
 		if err != nil {
@@ -93,6 +94,7 @@ func TestAcceptance(t *testing.T) {
 
 type Globals struct {
 	AppGuid              string `json:"app_guid"`
+	AppName              string `json:"app_name"`
 	AppsDomain           string `json:"apps_domain"`
 	SysComponentSelector string `json:"sys_component_selector"`
 }

--- a/test/acceptance/ingress_logging_test.go
+++ b/test/acceptance/ingress_logging_test.go
@@ -1,0 +1,34 @@
+package acceptance_test
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cloudfoundry-incubator/cf-test-helpers/cf"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("IngressLogging", func() {
+	When("a user sends a GET request to an app", func() {
+		It("produces an RTR log visible in cf logs", func() {
+			logSession := cf.Cf("logs", globals.AppName)
+
+			customTransport := http.DefaultTransport.(*http.Transport).Clone()
+			customTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+			client := &http.Client{Transport: customTransport}
+
+			_, err := client.Get(fmt.Sprintf("https://%s.%s", globals.AppName, globals.AppsDomain))
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(logSession, 10*time.Second).Should(gbytes.Say("RTR.*" + globals.AppGuid))
+
+			logSession.Kill()
+			Eventually(logSession).Should(gexec.Exit())
+		})
+	})
+})


### PR DESCRIPTION
### Summary of changes
This change is to propagate ingressgateway access logs (RTR logs) to the cf logging system so the access logs show up in `cf logs`.

This change introduces a second fluentd daemonset, which is used to capture logs from each ingressgateway, transform those logs, and send them to the cf logging fluentd.

We aren't 100% sure this is the direction we want to go with regards to the second fluentd daemonset decision. We want to hear people's opinions or thoughts on this decision.

We see the following tradeoffs with the approach:

**Pros:**
* A second fluentd daemonset keeps the configuration out of the [main fluentd config](https://github.com/cloudfoundry/cf-for-k8s/blob/master/config/_ytt_lib/github.com/cloudfoundry/cf-k8s-logging/config/300-fluentd-config.yaml) and keeps that clean abstraction boundary that exists. I.e the main fluentd daemonset focuses on generically capturing app logs and there isn't any specific configuration for individual components.

**Cons:**
* Keeping our fluentd image in sync with the cf-logging fluentd will cause toil. Currently our implementation has this image hardcoded to a random image digest of cf-k8s-logging.
* A second fluentd daemonset increases our overall resource requirements for the nodes running cf-for-k8s.

### Additional Context
https://www.pivotaltracker.com/story/show/173568724

### Acceptance Steps

As an App Developer
When I run `cf logs`
Then I can expect to see the ingress gateway-access logs in the following format:
`2020-06-25T23:42:19.00+0000 [RTR/0] OUT <log>`

cc @jenspinney
