### PR TITLE
feat: ingressgateway logs show up in `cf logs` [sidecar version]

### DIFF
--- a/config/istio-config/fluent-bit-ingressgateway-config-map.yaml
+++ b/config/istio-config/fluent-bit-ingressgateway-config-map.yaml
@@ -1,0 +1,52 @@
+#@ load("@ytt:data", "data")
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ingressgateway-fluent-bit-forwarder-config
+  namespace: istio-system
+data:
+  #@yaml/text-templated-strings
+  fluent-bit.conf: |-
+    [SERVICE]
+        Flush          1
+        Daemon         Off
+        Log_Level      info
+        Parsers_File   parsers.conf
+    [INPUT]
+        Name    tail
+        Tag     istio-ingressgateway
+        Path    /var/log/containers/istio-ingressgateway*istio-proxy*.log
+        Parser  json
+        Refresh_Interval 1
+    [FILTER]
+        Name parser
+        Match istio-ingressgateway
+        Parser json
+        Key_Name log
+    [FILTER]
+        Name lua
+        Match istio-ingressgateway
+        script transform_record.lua
+        call transform_record
+    [OUTPUT]
+        Name forward
+        Match istio-ingressgateway
+        Host fluentd-forwarder-ingress.(@= data.values.systemNamespace @)
+        Port 24224
+  parsers.conf : |-
+    [PARSER]
+        Name   json
+        Format json
+        Time_Key time
+  transform_record.lua: |-
+    function transform_record(tag, timestamp, record)
+      new_record = {}
+      new_record["app_id"] = record["app_id"]
+      new_record["instance_id"] = "0"
+      new_record["log"] = record
+      new_record["source_type"] = "RTR"
+      return 1, timestamp, new_record
+    end
+

--- a/config/istio-generated/xxx-generated-istio.yaml
+++ b/config/istio-generated/xxx-generated-istio.yaml
@@ -297,6 +297,127 @@ metadata:
   annotations:
     helm.sh/resource-policy: keep
   labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.6.4
+    heritage: Tiller
+    istio: mixer-adapter
+    package: adapter
+    release: istio
+  name: adapters.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: adapter
+    plural: adapters
+    singular: adapter
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
+    app: mixer
+    chart: istio
+    cloudfoundry.org/istio_version: 1.6.4
+    heritage: Tiller
+    istio: mixer-template
+    package: template
+    release: istio
+  name: templates.config.istio.io
+spec:
+  group: config.istio.io
+  names:
+    categories:
+    - istio-io
+    - policy-istio-io
+    kind: template
+    plural: templates
+    singular: template
+  scope: Namespaced
+  subresources:
+    status: {}
+  versions:
+  - name: v1alpha2
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  labels:
+    cloudfoundry.org/istio_version: 1.6.4
+    release: istio
+  name: istiooperators.install.istio.io
+spec:
+  additionalPrinterColumns:
+  - JSONPath: .spec.revision
+    description: Istio control plane revision
+    name: Revision
+    type: string
+  - JSONPath: .metadata.creationTimestamp
+    description: 'CreationTimestamp is a timestamp representing the server time when
+      this object was created. It is not guaranteed to be set in happens-before order
+      across separate operations. Clients may not set this value. It is represented
+      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
+      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
+    name: Age
+    type: date
+  group: install.istio.io
+  names:
+    kind: IstioOperator
+    plural: istiooperators
+    shortNames:
+    - iop
+    singular: istiooperator
+  scope: Namespaced
+  subresources:
+    status: {}
+  validation:
+    openAPIV3Schema:
+      properties:
+        apiVersion:
+          description: 'APIVersion defines the versioned schema of this representation
+            of an object. Servers should convert recognized schemas to the latest
+            internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
+          type: string
+        kind:
+          description: 'Kind is a string value representing the REST resource this
+            object represents. Servers may infer this from the endpoint the client
+            submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+          type: string
+        spec:
+          description: 'Specification of the desired state of the istio control plane
+            resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+        status:
+          description: 'Status describes each of istio control plane component status
+            at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY,
+            3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html
+            & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
+          type: object
+  versions:
+  - name: v1alpha1
+    served: true
+    storage: true
+---
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    helm.sh/resource-policy: keep
+  labels:
     app: istio-mixer
     chart: istio
     cloudfoundry.org/istio_version: 1.6.4
@@ -5199,127 +5320,6 @@ spec:
     served: true
     storage: true
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-adapter
-    package: adapter
-    release: istio
-  name: adapters.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: adapter
-    plural: adapters
-    singular: adapter
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  annotations:
-    helm.sh/resource-policy: keep
-  labels:
-    app: mixer
-    chart: istio
-    cloudfoundry.org/istio_version: 1.6.4
-    heritage: Tiller
-    istio: mixer-template
-    package: template
-    release: istio
-  name: templates.config.istio.io
-spec:
-  group: config.istio.io
-  names:
-    categories:
-    - istio-io
-    - policy-istio-io
-    kind: template
-    plural: templates
-    singular: template
-  scope: Namespaced
-  subresources:
-    status: {}
-  versions:
-  - name: v1alpha2
-    served: true
-    storage: true
----
-apiVersion: apiextensions.k8s.io/v1beta1
-kind: CustomResourceDefinition
-metadata:
-  labels:
-    cloudfoundry.org/istio_version: 1.6.4
-    release: istio
-  name: istiooperators.install.istio.io
-spec:
-  additionalPrinterColumns:
-  - JSONPath: .spec.revision
-    description: Istio control plane revision
-    name: Revision
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    description: 'CreationTimestamp is a timestamp representing the server time when
-      this object was created. It is not guaranteed to be set in happens-before order
-      across separate operations. Clients may not set this value. It is represented
-      in RFC3339 form and is in UTC. Populated by the system. Read-only. Null for
-      lists. More info: https://git.k8s.io/community/contributors/devel/api-conventions.md#metadata'
-    name: Age
-    type: date
-  group: install.istio.io
-  names:
-    kind: IstioOperator
-    plural: istiooperators
-    shortNames:
-    - iop
-    singular: istiooperator
-  scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        spec:
-          description: 'Specification of the desired state of the istio control plane
-            resource. More info: https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-        status:
-          description: 'Status describes each of istio control plane component status
-            at the current time. 0 means NONE, 1 means UPDATING, 2 means HEALTHY,
-            3 means ERROR, 4 means RECONCILING. More info: https://github.com/istio/api/blob/master/operator/v1alpha1/istio.operator.v1alpha1.pb.html
-            & https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status'
-          type: object
-  versions:
-  - name: v1alpha1
-    served: true
-    storage: true
----
 apiVersion: autoscaling/v2beta1
 kind: HorizontalPodAutoscaler
 metadata:
@@ -5353,6 +5353,11 @@ metadata:
           Type: resolved
           URL: gcr.io/cf-routing/proxyv2:1.6.4
         URL: gcr.io/cf-routing/proxyv2@sha256:4e4d05059e65080b158a347bcfac67090968e96f302dea54c0efac9a16ef62f0
+      - Metas:
+        - Tag: latest
+          Type: resolved
+          URL: cfrouting/fluent-bit
+        URL: index.docker.io/cfrouting/fluent-bit@sha256:e04d7985f1f8778952547bcc8c9dfeef0a9a078006ca28f6e9c4e5f455ef0eba
   labels:
     app: istio-ingressgateway
     cloudfoundry.org/istio_version: 1.6.4
@@ -5540,6 +5545,22 @@ spec:
         - mountPath: /etc/istio/ingressgateway-ca-certs
           name: ingressgateway-ca-certs
           readOnly: true
+      - image: index.docker.io/cfrouting/fluent-bit@sha256:e04d7985f1f8778952547bcc8c9dfeef0a9a078006ca28f6e9c4e5f455ef0eba
+        name: fluent-bit
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - mountPath: /fluent-bit/etc
+          name: fluent-bit-config
+        - mountPath: /var/log
+          name: varlog
+        - mountPath: /var/lib/docker/containers
+          name: dockercontainers
+          readOnly: true
       serviceAccountName: istio-ingressgateway-service-account
       terminationGracePeriodSeconds: 80
       volumes:
@@ -5578,6 +5599,15 @@ spec:
         secret:
           optional: true
           secretName: istio-ingressgateway-ca-certs
+      - configMap:
+          name: ingressgateway-fluent-bit-forwarder-config
+        name: fluent-bit-config
+      - hostPath:
+          path: /var/log
+        name: varlog
+      - hostPath:
+          path: /var/lib/docker/containers
+        name: dockercontainers
   updateStrategy:
     rollingUpdate:
       maxUnavailable: 1

--- a/istio-install/overlays/add-fluent-bit-sidecar-to-ingressgateway.yaml
+++ b/istio-install/overlays/add-fluent-bit-sidecar-to-ingressgateway.yaml
@@ -1,0 +1,48 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@ deployment = overlay.subset({"kind": "Deployment", "metadata":{"name":"istio-ingressgateway"}})
+#@ daemonset = overlay.subset({"kind": "DaemonSet", "metadata":{"name":"istio-ingressgateway"}})
+#@ match_ingress_gateway=overlay.or_op(deployment, daemonset)
+
+#@overlay/match by=match_ingress_gateway
+---
+spec:
+  template:
+    spec:
+      containers:
+      #@overlay/append
+      - name: fluent-bit
+        image: cfrouting/fluent-bit
+        resources:
+          limits:
+            memory: 100Mi
+          requests:
+            cpu: 10m
+            memory: 10Mi
+        volumeMounts:
+        - name: fluent-bit-config
+          mountPath: /fluent-bit/etc
+        - name: varlog
+          mountPath: /var/log
+        - name: dockercontainers
+          mountPath: /var/lib/docker/containers
+          readOnly: true
+
+#@overlay/match by=match_ingress_gateway
+---
+spec:
+  template:
+    spec:
+      volumes:
+      #@overlay/append
+      - name: fluent-bit-config
+        configMap:
+          name: ingressgateway-fluent-bit-forwarder-config
+      #@overlay/append
+      - name: varlog
+        hostPath:
+          path: /var/log
+      #@overlay/append
+      - name: dockercontainers
+        hostPath:
+          path: /var/lib/docker/containers


### PR DESCRIPTION
In our PR, we use fluent-bit as a sidecar instead of as a daemonset (which was done in the previous draft [here](https://github.com/cloudfoundry/cf-k8s-networking/pull/57)). We have deployed to a cf-for-k8s cluster and it works 🎉 

We used cf-k8s-logging-fluent's [fluent-bit dockerfile](https://github.com/cloudfoundry/cf-k8s-logging-fluent/blob/master/fluent-bit/Dockerfile) to build the fluent-bit images.

Note, istio-ingressgateways do not have an Istio sidecar so we needed to add a PeerAuthentication to all plaintext traffic to fluentd; this is not ideal.


[#173568724](https://www.pivotaltracker.com/story/show/173568724)
