### PR TITLE
Add an overlay to provision creds and configure mTLS for Prometheus

### DIFF
--- a/config/provision-prometheus-certs.yaml
+++ b/config/provision-prometheus-certs.yaml
@@ -1,0 +1,143 @@
+#@ load("@ytt:data", "data")
+#@ load("@ytt:json", "json")
+#@ load("@ytt:yaml", "yaml")
+#@ load("@ytt:overlay", "overlay")
+
+#@ prometheus_labels={"app": "prometheus", "component": "server"}
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata": {"labels": prometheus_labels}})
+---
+spec:
+  template:
+    metadata:
+      #@overlay/match missing_ok=True
+      annotations:
+        #@overlay/match missing_ok=True
+        sidecar.istio.io/inject: "false"
+    spec:
+      containers:
+      - #@overlay/match by=overlay.subset({"name":"prometheus-server"})
+        volumeMounts:
+        #@overlay/append
+        - mountPath: /etc/istio-certs
+          name: istio-certs
+      #@overlay/append
+      - name: istio-proxy
+        #@yaml/text-templated-strings
+        image: gcr.io/cf-routing/proxyv2:(@= data.values.istioVersion @)
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 15090
+          protocol: TCP
+          name: http-envoy-prom
+        args:
+        - proxy
+        - sidecar
+        - --domain
+        - $(POD_NAMESPACE).svc.cluster.local
+        - istio-proxy-prometheus
+        - --proxyLogLevel=warning
+        - --proxyComponentLogLevel=misc:error
+        - --controlPlaneAuthPolicy
+        - NONE
+        - --trust-domain=cluster.local
+        env:
+        - name: OUTPUT_CERTS
+          value: /etc/istio-certs
+        - name: JWT_POLICY
+          value: third-party-jwt
+        - name: PILOT_CERT_PROVIDER
+          value: istiod
+        - name: CA_ADDR
+          value: istiod.istio-system.svc:15012
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: INSTANCE_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: SERVICE_ACCOUNT
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.serviceAccountName
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        - name: ISTIO_META_MESH_ID
+          value: cluster.local
+        - name: ISTIO_META_CLUSTER_ID
+          value: Kubernetes
+        readinessProbe:
+          failureThreshold: 30
+          httpGet:
+            path: /healthz/ready
+            port: 15020
+            scheme: HTTP
+          initialDelaySeconds: 1
+          periodSeconds: 2
+          successThreshold: 1
+          timeoutSeconds: 1
+        volumeMounts:
+        - mountPath: /var/run/secrets/istio
+          name: istiod-ca-cert
+        - mountPath: /etc/istio/proxy
+          name: istio-envoy
+        - mountPath: /var/run/secrets/tokens
+          name: istio-token
+        - mountPath: /etc/istio-certs/
+          name: istio-certs
+        - mountPath: /etc/istio/config
+          name: istio-config-volume
+      volumes:
+      #@overlay/append
+      - name: istio-config-volume
+        configMap:
+          name: istio
+          optional: true
+      #@overlay/append
+      - name: istio-certs
+        emptyDir:
+            medium: Memory
+      #@overlay/append
+      - name: istio-envoy
+        emptyDir:
+          medium: Memory
+      #@overlay/append
+      - name: istio-token
+        projected:
+          defaultMode: 420
+          sources:
+          - serviceAccountToken:
+              audience: istio-ca
+              expirationSeconds: 43200
+              path: istio-token
+      #@overlay/append
+      - name: istiod-ca-cert
+        configMap:
+            defaultMode: 419
+            name: istio-ca-root-cert
+#@ def add_mtls_config():
+scrape_configs:
+- #@overlay/match by=overlay.or_op(overlay.subset({"job_name":"kubernetes-pods"}),overlay.subset({"job_name":"kubernetes-pods-slow"})),expects=2
+  #@overlay/match missing_ok=True
+  scheme: https
+  #@overlay/match missing_ok=True
+  tls_config:
+    ca_file: /etc/istio-certs/root-cert.pem
+    cert_file: /etc/istio-certs/cert-chain.pem
+    key_file: /etc/istio-certs/key.pem
+    insecure_skip_verify: true  #! prometheus does not support secure naming.
+#@ end
+
+#@overlay/match by=overlay.subset({"kind": "ConfigMap", "metadata": {"labels": prometheus_labels}})
+---
+
+data:
+  #@overlay/replace via=lambda a,_: json.encode(overlay.apply(yaml.decode(a),add_mtls_config()))
+  prometheus.yml:


### PR DESCRIPTION
To allow Prometheus to communicate with Istio sidecar injected pods it has to have required credentials. To provision these credentials we manually inject istio-proxy sidecar to the Prometheus server deployment generated by `helm template cf-for-k8s-prometheus stable/prometheus -n cf-system --set server.podLabels.what\-am\-i=prometheus` command. The proxy sidecar will generate the key and certificates and put them to `/etc/istio-certs`. Then we configure Prometheus config to use these certs for requesting metrics endpoints on the node.

To test this overlay you have to deploy Prometheus. Follow [Prometheus installation guideline](https://github.com/cloudfoundry/cf-for-k8s-metric-examples#deploying-prometheus-server) from cf-for-k8s-metric team but instead of using `helm install` use `helm template` and save the generated YAML to some file, then apply the overlay by `ytt -f <prometheus.yaml> -f config/values.yaml -f config/provision-prometheus-certs.yaml`

The overlay is based on:
- [Provision a certificate and key for an application without sidecars](https://istio.io/latest/blog/2020/proxy-cert/)
- [Istio's Prometheus deployment template](https://github.com/istio/istio/blob/release-1.6/manifests/charts/istio-telemetry/prometheus/templates/deployment.yaml)
- [Istio's Prometheus configmap template](https://github.com/istio/istio/blob/release-1.6/manifests/charts/istio-telemetry/prometheus/templates/configmap.yaml#L259l)

[#174408928](https://www.pivotaltracker.com/story/show/174408928)