### PR TITLE
remove HPA and make istiod replicas configurable

### DIFF
--- a/config/istio-config/remove-hpas-and-scale-istiod.yaml
+++ b/config/istio-config/remove-hpas-and-scale-istiod.yaml
@@ -1,0 +1,13 @@
+#@ load("@ytt:overlay", "overlay")
+
+#@ load("@ytt:data", "data")
+
+#@overlay/match by=overlay.subset({"kind":"HorizontalPodAutoscaler"}), expects="1+"
+#@overlay/remove
+---
+
+#@overlay/match by=overlay.subset({"kind": "Deployment", "metadata":{"name":"istiod"}}),expects=1
+---
+spec:
+  #@overlay/match missing_ok=True
+  replicas: #@ data.values.istiod.replicas

--- a/config/values.yaml
+++ b/config/values.yaml
@@ -7,6 +7,9 @@ istioVersion: 1.6.4
 systemNamespace: cf-system
 workloadsNamespace: cf-workloads
 
+istiod:
+  replicas: 1
+
 routecontroller:
   image: gcr.io/cf-networking-images/cf-k8s-networking/routecontroller@sha256:85f3dd3ad45cc2e0c2ca73181537d681b0013e1329247880b156421c7bde7a80
 upgradeSidecars:


### PR DESCRIPTION
- the ingressgateway one does not function, because we deploy a
daemonset
- we know from previous research that hpas do not help overloaded
pilot/istiods
- defaults to 1 istiod for proof-of-concept/local deployments

Co-authored-by: Clay Kauzlaric <ckauzlaric@vmware.com>
