### PR TITLE
Update org_routes crd for Kubernetes 1.22

### DIFF
--- a/config/crd/networking.cloudfoundry.org_routes.yaml
+++ b/config/crd/networking.cloudfoundry.org_routes.yaml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:


### PR DESCRIPTION
### Summary of changes
Use stable APIs. [Several deprecated APIs were removed in Kubernetes 1.22.](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/)

### Additional Context
[Kubernetes API and Feature Removals In 1.22: Here’s What You Need To Know](https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/)
